### PR TITLE
[FEAT] Implement Swagger for API Documentation and Custom NoHandlerFound Exception Handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
 			<artifactId>rest-assured</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/hng_java_boilerplate/product/errorhandler/ProductErrorHandler.java
+++ b/src/main/java/hng_java_boilerplate/product/errorhandler/ProductErrorHandler.java
@@ -1,16 +1,25 @@
 package hng_java_boilerplate.product.errorhandler;
 
+import hng_java_boilerplate.product.dto.ErrorDTO;
+import hng_java_boilerplate.product.dto.ProductErrorDTO;
 import hng_java_boilerplate.product.dto.ProductValidatorDTO;
 import hng_java_boilerplate.product.exceptions.ValidationError;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.List;
 
 @ControllerAdvice
 public class ProductErrorHandler {
+
+    private final ProductErrorDTO productErrorDTO;
+
+    public ProductErrorHandler(ProductErrorDTO productErrorDTO) {
+        this.productErrorDTO = productErrorDTO;
+    }
 
     @ExceptionHandler
     public ResponseEntity<?> handleException(ValidationError v){
@@ -19,5 +28,13 @@ public class ProductErrorHandler {
         dto.setStatus_code(HttpStatus.UNPROCESSABLE_ENTITY.value());
         dto.setSuccess(false);
         return new ResponseEntity<>(dto, HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<?> handleException(NoHandlerFoundException ex){
+        productErrorDTO.setMessage("Resource not found");
+        productErrorDTO.setStatus_code(HttpStatus.NOT_FOUND.value());
+        productErrorDTO.setSuccess(false);
+        return new ResponseEntity<>(productErrorDTO, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,7 @@ spring.datasource.hikari.pool-name=HikariCP
 spring.datasource.hikari.max-lifetime=1800000
 spring.datasource.hikari.connection-timeout=20000
 spring.datasource.hikari.leak-detection-threshold=15000
+
+#configures Spring Boot to throw an exception if no handler is found for a request
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false


### PR DESCRIPTION

### Description

This PR implements Swagger for API documentation and adds custom handling for `NoHandlerFoundException` in the Spring Boot application. The following changes have been made:

1. **Swagger Integration:**
   - Added the `springdoc-openapi-starter-webmvc-ui` dependency to `pom.xml`.

2. **Custom NoHandlerFound Exception Handling:**
   - Configured Spring to throw `NoHandlerFoundException` when no handler is found for a request.
   - Added a custom exception handler to return a detailed error response with a 404 status code.


### How to Test

1. **Swagger UI:**
   - Start the application and navigate to `http://localhost:8080/swagger-ui/index.html` to see the API documentation.

2. **Custom 404 Handling:**
   - Send a request to a non-existent endpoint (e.g., `http://localhost:8080/api/v1/non-existent`).
   - Verify that the response contains a 404 status and a JSON body with the custom error message.

