### PR TITLE
feat: user deactivation endpoint

### DIFF
--- a/src/main/java/hng_java_boilerplate/exception/BadRequestException.java
+++ b/src/main/java/hng_java_boilerplate/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package hng_java_boilerplate.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/exception/CustomError.java
+++ b/src/main/java/hng_java_boilerplate/exception/CustomError.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.exception;
+
+public record CustomError(int status_code, String error) {
+}

--- a/src/main/java/hng_java_boilerplate/exception/ValidationError.java
+++ b/src/main/java/hng_java_boilerplate/exception/ValidationError.java
@@ -1,0 +1,17 @@
+package hng_java_boilerplate.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationError {
+    private int status_code;
+    private String error;
+    private Map<String, String> detail;
+
+}

--- a/src/main/java/hng_java_boilerplate/profile/controller/ProfileController.java
+++ b/src/main/java/hng_java_boilerplate/profile/controller/ProfileController.java
@@ -1,0 +1,24 @@
+package hng_java_boilerplate.profile.controller;
+
+import hng_java_boilerplate.profile.dto.request.DeactivateUserRequest;
+import hng_java_boilerplate.profile.dto.response.DeactivateUserResponse;
+import hng_java_boilerplate.profile.service.ProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/accounts")
+public class ProfileController {
+    private final ProfileService profileService;
+
+    @PatchMapping("/deactivate")
+    public ResponseEntity<DeactivateUserResponse> deactivateUser(@RequestBody @Valid DeactivateUserRequest request) {
+        return ResponseEntity.ok(profileService.deactivateUser(request));
+    }
+}

--- a/src/main/java/hng_java_boilerplate/profile/dto/request/DeactivateUserRequest.java
+++ b/src/main/java/hng_java_boilerplate/profile/dto/request/DeactivateUserRequest.java
@@ -1,0 +1,13 @@
+package hng_java_boilerplate.profile.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DeactivateUserRequest {
+    private String reason;
+    @NotBlank(message = "Deactivation confirmation is required")
+    private String confirmation;
+}

--- a/src/main/java/hng_java_boilerplate/profile/dto/response/DeactivateUserResponse.java
+++ b/src/main/java/hng_java_boilerplate/profile/dto/response/DeactivateUserResponse.java
@@ -1,0 +1,3 @@
+package hng_java_boilerplate.profile.dto.response;
+
+public record DeactivateUserResponse(int status_code, String message) {}

--- a/src/main/java/hng_java_boilerplate/profile/service/ProfileService.java
+++ b/src/main/java/hng_java_boilerplate/profile/service/ProfileService.java
@@ -1,0 +1,8 @@
+package hng_java_boilerplate.profile.service;
+
+import hng_java_boilerplate.profile.dto.request.DeactivateUserRequest;
+import hng_java_boilerplate.profile.dto.response.DeactivateUserResponse;
+
+public interface ProfileService {
+    public DeactivateUserResponse deactivateUser(DeactivateUserRequest request);
+}

--- a/src/main/java/hng_java_boilerplate/profile/serviceImpl/ProfileServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/profile/serviceImpl/ProfileServiceImpl.java
@@ -1,0 +1,39 @@
+package hng_java_boilerplate.profile.serviceImpl;
+
+import hng_java_boilerplate.exception.BadRequestException;
+import hng_java_boilerplate.profile.dto.request.DeactivateUserRequest;
+import hng_java_boilerplate.profile.dto.response.DeactivateUserResponse;
+import hng_java_boilerplate.profile.service.ProfileService;
+import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.repository.UserRepository;
+import hng_java_boilerplate.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class ProfileServiceImpl implements ProfileService {
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    @Override
+    public DeactivateUserResponse deactivateUser(DeactivateUserRequest request) {
+        User authUser = userService.getLoggedInUser();
+
+        String confirmation = request.getConfirmation().toLowerCase();
+
+        if (confirmation.equals("true") && authUser.getIsDeactivated()) {
+            throw new BadRequestException("User has been deactivated");
+        }
+
+        if (!confirmation.equals("true")) throw new BadRequestException("Confirmation needs to be true for deactivation");
+
+        authUser.setIsDeactivated(true);
+        userRepository.save(authUser);
+
+        //todo: call email service to notify user of account deactivated
+
+        return new DeactivateUserResponse(200, "Account Deactivated Successfully");
+    }
+}

--- a/src/main/java/hng_java_boilerplate/user/entity/User.java
+++ b/src/main/java/hng_java_boilerplate/user/entity/User.java
@@ -58,6 +58,9 @@ public class User implements UserDetails {
     @JsonIgnore
     private Boolean isEnabled = false;
 
+    @JsonIgnore
+    private Boolean isDeactivated = false;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/hng_java_boilerplate/user/service/UserService.java
+++ b/src/main/java/hng_java_boilerplate/user/service/UserService.java
@@ -3,6 +3,7 @@ package hng_java_boilerplate.user.service;
 import hng_java_boilerplate.user.dto.request.GetUserDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
+import hng_java_boilerplate.user.entity.User;
 import org.springframework.http.ResponseEntity;
 
 import javax.crypto.BadPaddingException;
@@ -10,5 +11,5 @@ import javax.crypto.BadPaddingException;
 public interface UserService {
     GetUserDto getUserWithDetails(String userId) throws BadPaddingException;
     ResponseEntity<ApiResponse> registerUser(SignupDto signupDto);
-
+    User getLoggedInUser();
 }

--- a/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -46,6 +47,9 @@ public class UserServiceImpl implements UserDetailsService, UserService {
         Optional<User> user = userRepository.findByEmail(username);
         if (user.isEmpty()) {
             throw new UsernameNotFoundException("User not found");
+        }
+        if (user.get().getIsDeactivated()) {
+            throw new DisabledException("user is deactivated");
         }
         return user.get();
     }
@@ -94,6 +98,7 @@ public class UserServiceImpl implements UserDetailsService, UserService {
         }
     }
 
+    @Override
     public User getLoggedInUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();

--- a/src/main/resources/db/migration/V4__alter_user_table.sql
+++ b/src/main/resources/db/migration/V4__alter_user_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN is_deactivated BOOLEAN DEFAULT FALSE;

--- a/src/test/java/hng_java_boilerplate/profile/controller/ProfileControllerTest.java
+++ b/src/test/java/hng_java_boilerplate/profile/controller/ProfileControllerTest.java
@@ -1,0 +1,69 @@
+package hng_java_boilerplate.profile.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hng_java_boilerplate.product.errorhandler.ProductErrorHandler;
+import hng_java_boilerplate.profile.dto.request.DeactivateUserRequest;
+import hng_java_boilerplate.profile.dto.response.DeactivateUserResponse;
+import hng_java_boilerplate.profile.service.ProfileService;
+import hng_java_boilerplate.util.JwtUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(ProfileController.class)
+@ExtendWith(MockitoExtension.class)
+class ProfileControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private ProfileService profileService;
+    @MockBean
+    private ProductErrorHandler productErrorHandler;
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @Test
+    void shouldCreateMockMvC() {
+        assertThat(mockMvc).isNotNull();
+    }
+
+    @Test
+    void shouldDeactivateUser() throws Exception {
+        // request
+        DeactivateUserRequest request = DeactivateUserRequest
+                .builder()
+                .confirmation("TRUE")
+                .build();
+
+        // mock response
+        DeactivateUserResponse response =
+                new DeactivateUserResponse(200, "user deactivated successfully");
+
+        // mock service
+        when(profileService.deactivateUser(request)).thenReturn(response);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestString = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(patch("/api/v1/accounts/deactivate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestString))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status_code").value(200))
+                .andExpect(jsonPath("$.message").value(response.message()));
+    }
+}

--- a/src/test/java/hng_java_boilerplate/profile/serviceImpl/ProfileServiceImplTest.java
+++ b/src/test/java/hng_java_boilerplate/profile/serviceImpl/ProfileServiceImplTest.java
@@ -1,0 +1,111 @@
+package hng_java_boilerplate.profile.serviceImpl;
+
+import hng_java_boilerplate.exception.BadRequestException;
+import hng_java_boilerplate.profile.dto.request.DeactivateUserRequest;
+import hng_java_boilerplate.profile.dto.response.DeactivateUserResponse;
+import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.repository.UserRepository;
+import hng_java_boilerplate.user.service.UserService;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceImplTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserService userService;
+    @InjectMocks
+    private ProfileServiceImpl underTest;
+
+    @Test
+    void shouldDeactivateUser() {
+        // mock auth user;
+        User authUser = new User();
+        authUser.setName("Test User");
+        authUser.setEmail("test@user.com");
+        authUser.setIsDeactivated(false);
+
+        // set request
+        DeactivateUserRequest request = DeactivateUserRequest
+                .builder()
+                .reason("private")
+                .confirmation("true")
+                .build();
+
+        // mock response
+        DeactivateUserResponse response =
+                new DeactivateUserResponse(200, "Account Deactivated Successfully");
+
+        when(userService.getLoggedInUser()).thenReturn(authUser);
+        doAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            user.setIsDeactivated(true);
+            return null;
+        }).when(userRepository).save(any(User.class));
+
+        DeactivateUserResponse res = underTest.deactivateUser(request);
+
+        verify(userRepository, times(1)).save(authUser);
+
+        assertThat(res.status_code()).isEqualTo(response.status_code());
+        assertThat(res.message()).isEqualTo(response.message());
+    }
+
+    @Test
+    void shouldThrowWhenConfirmationNotTrue() {
+        // mock auth user;
+        User authUser = new User();
+        authUser.setName("Test User");
+        authUser.setEmail("test@user.com");
+
+        // set request
+        DeactivateUserRequest request = DeactivateUserRequest
+                .builder()
+                .confirmation("false")
+                .build();
+
+        when(userService.getLoggedInUser()).thenReturn(authUser);
+
+        assertThatThrownBy(() -> underTest.deactivateUser(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Confirmation needs to be true for deactivation");
+    }
+
+    @Test
+    void shouldThrowWhenNoAuthUser() {
+        // mock request
+        DeactivateUserRequest request = DeactivateUserRequest.builder().build();
+        assertThatThrownBy(() -> underTest.deactivateUser(request));
+    }
+
+    @Test
+    void shouldThrowWhenUserAlreadyDeactivated() {
+        // mock auth user
+        User authUser = new User();
+        authUser.setName("Test User");
+        authUser.setEmail("test@user.com");
+        authUser.setIsDeactivated(true);
+
+        // set request
+        DeactivateUserRequest request = DeactivateUserRequest
+                .builder()
+                .confirmation("true")
+                .build();
+
+        when(userService.getLoggedInUser()).thenReturn(authUser);
+
+        assertThatThrownBy(() -> underTest.deactivateUser(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("User has been deactivated");
+    }
+}


### PR DESCRIPTION
## How should this be manually tested?
### The endpoint point is protected
#### Trying to access endpoint 
- without being authenticated
- with expired token
- with invalid token
**Response: 403 Forbidden response**

### checklist of what is done

- [ ] updated the users database with field to deactivate user
- [ ] updated authentication to not allow disabled user access to resources
- [ ] implemented code to deactivate a user
- [ ] get the authenticated user and deactivates the user
- [ ] implements validation for required fields

Reference Issue
[FEAT: User Deactivation](https://github.com/hngprojects/hng_boilerplate_java_web/issues/15)