### PR TITLE
feat:delete product feature#14

### DIFF
--- a/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
+++ b/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package hng_java_boilerplate.config;
 
+import hng_java_boilerplate.user.enums.Role;
 import hng_java_boilerplate.user.serviceImpl.UserServiceImpl;
 import hng_java_boilerplate.util.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +72,7 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(httpRequests ->
                         httpRequests
-//                                .requestMatchers("").hasAuthority(String.valueOf(Role.ADMIN))
+                                .requestMatchers("/api/v1/products/{id}").hasAuthority(String.valueOf(Role.ROLE_ADMIN))
                                 .requestMatchers("/", "/v3/api-docs", "/swagger-ui/index.html" ,"/api/v1/auth/**").permitAll()
                                 .requestMatchers("/api/v1/auth/logout","/api/**").authenticated())
                 .logout(logout -> logout

--- a/src/main/java/hng_java_boilerplate/product/controller/ProductController.java
+++ b/src/main/java/hng_java_boilerplate/product/controller/ProductController.java
@@ -1,7 +1,10 @@
 package hng_java_boilerplate.product.controller;
 
+import hng_java_boilerplate.product.dto.ProductErrorDTO;
 import hng_java_boilerplate.product.dto.ProductSearchDTO;
 import hng_java_boilerplate.product.entity.Product;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
 import hng_java_boilerplate.product.product_mapper.ProductMapper;
 import hng_java_boilerplate.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -60,5 +60,21 @@ public class ProductController {
         productSearchDTO.setPage(products.getNumber());
         productSearchDTO.setSuccess(true);
         return new ResponseEntity<>(productSearchDTO, HttpStatus.OK);
+    }
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteProductById(@PathVariable String id){
+        try{
+            productService.deleteProductById(id);
+            return ResponseEntity.noContent().build();
+        }catch (ProductNotFoundException e){
+            ProductErrorDTO errorDTO = new ProductErrorDTO(false,"Product not found",HttpStatus.NOT_FOUND.value());
+            return new ResponseEntity<>(errorDTO, HttpStatus.NOT_FOUND);
+        }catch (UnauthorizedAccessException e){
+            ProductErrorDTO errorDTO = new ProductErrorDTO(false,"You do not have permission to delete this product",HttpStatus.FORBIDDEN.value());
+            return new ResponseEntity<>(errorDTO, HttpStatus.FORBIDDEN);
+        }catch (Exception e){
+            ProductErrorDTO errorDTO = new ProductErrorDTO(false,"Internal server error",HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return new ResponseEntity<>(errorDTO, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/hng_java_boilerplate/product/exceptions/ProductNotFoundException.java
+++ b/src/main/java/hng_java_boilerplate/product/exceptions/ProductNotFoundException.java
@@ -1,0 +1,7 @@
+package hng_java_boilerplate.product.exceptions;
+
+public class ProductNotFoundException extends RuntimeException{
+    public ProductNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/product/exceptions/UnauthorizedAccessException.java
+++ b/src/main/java/hng_java_boilerplate/product/exceptions/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package hng_java_boilerplate.product.exceptions;
+
+public class UnauthorizedAccessException extends RuntimeException{
+    public UnauthorizedAccessException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/product/service/ProductService.java
+++ b/src/main/java/hng_java_boilerplate/product/service/ProductService.java
@@ -1,13 +1,15 @@
 package hng_java_boilerplate.product.service;
 
 import hng_java_boilerplate.product.entity.Product;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 public interface ProductService {
 
     //Method to Search for products with certain criteria, returns a list of products
     Page<Product> productsSearch(String name, String category, Double minPrice, Double maxPrice, Pageable pageable);
+
+    void deleteProductById(String id) throws ProductNotFoundException, UnauthorizedAccessException;
 }

--- a/src/test/java/hng_java_boilerplate/product_test/e2e/ProductDeleteE2e.java
+++ b/src/test/java/hng_java_boilerplate/product_test/e2e/ProductDeleteE2e.java
@@ -1,0 +1,20 @@
+package hng_java_boilerplate.product_test.e2e;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ProductDeleteE2e {
+    @BeforeAll
+    public static void setup(){
+        RestAssured.baseURI = "http://localhost:8080";
+    }
+    @Test
+    public void whenDeleteNonExistentProduct_thenReturnNotFound(){
+        String invalidProductId = "invalidProductId";
+        given().contentType("application/json").when().delete("/api/v1/products"+ invalidProductId).then().statusCode(404).body("status_code",equalTo(404)).body("message",equalTo("Product not found"));
+    }
+}

--- a/src/test/java/hng_java_boilerplate/product_test/unit_test/ProductDeleteTest.java
+++ b/src/test/java/hng_java_boilerplate/product_test/unit_test/ProductDeleteTest.java
@@ -1,0 +1,70 @@
+package hng_java_boilerplate.product_test.unit_test;
+
+import hng_java_boilerplate.product.entity.Product;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
+import hng_java_boilerplate.product.repository.ProductRepository;
+import hng_java_boilerplate.product.service.ProductServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class ProductDeleteTest {
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductServiceImpl productService;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+    }
+    @Test
+    public void testDeleteProduct_ValidId_Success(){
+        String productId = "invalidProductId";
+        Product product = new Product();
+        doReturn(java.util.Optional.of(product)).when(productRepository).findById(productId);
+        doNothing().when(productRepository).delete(product);
+        productService.deleteProductById(productId);
+        verify(productRepository,times(1)).delete(product);
+    }
+    @Test
+    public void testDeleteProduct_ProductNotFound_ThrowsProductNotFoundException(){
+        String productId = "invalidProductId";
+        doReturn(java.util.Optional.empty()).when(productRepository).findById(productId);
+        ProductNotFoundException thrown = assertThrows(ProductNotFoundException.class, () ->{
+            productService.deleteProductById(productId);
+        });
+        assertEquals("Product not found", thrown.getMessage());
+    }
+    @Test
+    public void testDeleteProduct_UnauthorizedAccess_ThrowsUnauthorizedAccessException(){
+        String productId = "ValidProductId";
+        Product product = new Product();
+        doReturn(java.util.Optional.of(product)).when(productRepository).findById(productId);
+        doThrow(new UnauthorizedAccessException("You do not have permission to delete this product")).when(productService).deleteProductById(productId);
+        UnauthorizedAccessException thrown = assertThrows(UnauthorizedAccessException.class, () ->{
+            productService.deleteProductById(productId);
+        });
+        assertEquals("You do not have permission to delete this product", thrown.getMessage());
+    }
+    @Test
+    public void testDeleteProduct_Exception_ReturnsInternalServerError() {
+        String productId = "ValidProductId";
+        Product product = new Product();
+        doReturn(java.util.Optional.of(product)).when(productRepository).findById(productId);
+        doThrow(new RuntimeException("Database error")).when(productService).deleteProductById(productId);
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->{
+            productService.deleteProductById(productId);
+        });
+        assertEquals("Database error", thrown.getMessage());
+    }
+    }
+


### PR DESCRIPTION
## New API Endpoint for Deleting Products

This pull request implements a new API endpoint for deleting products. The endpoint includes proper authentication and error handling mechanisms to ensure secure and accurate product management.

### Changes:

#### API Endpoint:
- Created the endpoint `/api/v1/products/{id}` to delete a specific product by its ID.

#### Request Handling:
- Utilized `@DeleteMapping` to map the HTTP DELETE request to the endpoint.
- Incorporated path variable for the product ID to identify the product to be deleted.

#### Security and Permissions:
- Ensured that only authenticated users with appropriate permissions (e.g., admin) can delete products.
- Added logic to check user permissions before allowing product deletion.

#### Error Handling:
- Implemented error handling for the following scenarios:
  - Product not found: Returns a `404 Not Found` status with a detailed error message.
  - Unauthorized access: Returns a `403 Forbidden` status if the user lacks permission to delete the product.
  - Internal server errors: Returns a `500 Internal Server Error` status for unexpected issues.

### Response Structure:
- On successful deletion:
  - Returns a `204 No Content` status.
- On error:
  - Returns an error object with `status_code` and `message` fields indicating the nature of the error.

### Testing:
- **Unit Tests:**
  - Verified that the `deleteProductById` method in `ProductService` correctly handles product deletion.
  - Tested scenarios where the product is not found or the user is unauthorized.

- **Integration Tests:**
  - Tested that `404 Not Found` is returned for nonexistent products.
  

### Issue:
Implements the feature for deleting products securely, ensuring proper authentication, permission checks, and error handling. This enhances the application by preventing unauthorized actions and providing clear feedback for various scenarios.