### PR TITLE
Fix: column "password" of relation "users" contains null values

### DIFF
--- a/src/main/resources/db/migration/V3__update_users_and_related_tables.sql
+++ b/src/main/resources/db/migration/V3__update_users_and_related_tables.sql
@@ -1,10 +1,6 @@
 -- Add new columns to users table
-UPDATE users
-SET password = 'default_password'
-WHERE password IS NULL;
-
 ALTER TABLE users
-    ADD COLUMN password VARCHAR(255) NOT NULL,
+    ADD COLUMN password VARCHAR(255) NULL,
     ADD COLUMN user_role VARCHAR(255),
     ADD COLUMN is_enabled BOOLEAN DEFAULT FALSE,
     ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/main/resources/db/migration/V3__update_users_and_related_tables.sql
+++ b/src/main/resources/db/migration/V3__update_users_and_related_tables.sql
@@ -1,4 +1,8 @@
 -- Add new columns to users table
+UPDATE users
+SET password = 'default_password'
+WHERE password IS NULL;
+
 ALTER TABLE users
     ADD COLUMN password VARCHAR(255) NOT NULL,
     ADD COLUMN user_role VARCHAR(255),

--- a/src/main/resources/db/migration/V5__alter_user_data.sql
+++ b/src/main/resources/db/migration/V5__alter_user_data.sql
@@ -1,0 +1,4 @@
+UPDATE users
+SET password = 'default_password'
+WHERE password IS NULL;
+

--- a/src/main/resources/db/migration/V5__alter_user_table.sql
+++ b/src/main/resources/db/migration/V5__alter_user_table.sql
@@ -1,6 +1,0 @@
-UPDATE users
-SET password = 'default_password'
-WHERE password IS NULL;
-
-ALTER TABLE users
-ALTER COLUMN password SET NOT NULL;

--- a/src/main/resources/db/migration/V5__alter_user_table.sql
+++ b/src/main/resources/db/migration/V5__alter_user_table.sql
@@ -1,0 +1,6 @@
+UPDATE users
+SET password = 'default_password'
+WHERE password IS NULL;
+
+ALTER TABLE users
+ALTER COLUMN password SET NOT NULL;

--- a/src/main/resources/db/migration/V6__alter_user_password.sql
+++ b/src/main/resources/db/migration/V6__alter_user_password.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ALTER COLUMN password SET NOT NULL;


### PR DESCRIPTION

## How should this be manually tested
1. This migration should be reviewed and tested in a development environment before applying to production.
2. Verify that existing rows with `NULL` passwords in the `users` table are updated to `default_password`.
3. Ensure that the `password` column enforces the `NOT NULL` constraint, and no new `NULL` values can be inserted.

## Checklist list of what i did
- [x] Created a migration script to update the `password` column in the `users` table.
- [x] Ensured that all existing `NULL` values in the column are updated to a default value.
- [x] Migration script created and committed.
- [x] Properly tested the migration in the local environment.

## Reference issue
[[BugFix]: Fix Migration Error for Users Table](https://github.com/hngprojects/hng_boilerplate_java_web/issues/141)