### PR TITLE
Feat/add users to organisation api feature

### DIFF
--- a/src/main/java/hng_java_boilerplate/exception/OrganisationNotFoundException.java
+++ b/src/main/java/hng_java_boilerplate/exception/OrganisationNotFoundException.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.exception;
+
+public class OrganisationNotFoundException extends RuntimeException{
+}

--- a/src/main/java/hng_java_boilerplate/exception/UnauthorizedAccessException.java
+++ b/src/main/java/hng_java_boilerplate/exception/UnauthorizedAccessException.java
@@ -1,0 +1,8 @@
+package hng_java_boilerplate.exception;
+
+public class UnauthorizedAccessException extends RuntimeException{
+
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/exception/UserAlreadyAssignedException.java
+++ b/src/main/java/hng_java_boilerplate/exception/UserAlreadyAssignedException.java
@@ -1,0 +1,7 @@
+package hng_java_boilerplate.exception;
+
+public class UserAlreadyAssignedException extends RuntimeException {
+    public UserAlreadyAssignedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/exception/UserNotFoundException.java
+++ b/src/main/java/hng_java_boilerplate/exception/UserNotFoundException.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.exception;
+
+public class UserNotFoundException extends RuntimeException{
+}

--- a/src/main/java/hng_java_boilerplate/organisation/Controller/OrganisationController.java
+++ b/src/main/java/hng_java_boilerplate/organisation/Controller/OrganisationController.java
@@ -1,0 +1,25 @@
+package hng_java_boilerplate.organisation.Controller;
+
+import hng_java_boilerplate.organisation.ServiceImpl.OrganisationService;
+import hng_java_boilerplate.organisation.dto.AddUserToOrganisationRequestDto;
+import hng_java_boilerplate.organisation.dto.OrganisationResponseDto;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/organisations")
+public class OrganisationController {
+    @Autowired
+    private OrganisationService organisationService;
+
+    @PostMapping("/{orgId}/users")
+    public ResponseEntity<?> addUserToOrganisation(@PathVariable String orgId, @Valid @RequestBody AddUserToOrganisationRequestDto request,
+            Authentication authentication) {
+        OrganisationResponseDto responseDTO = organisationService.addUserToOrganisation(orgId, request, authentication);
+        return ResponseEntity.ok(responseDTO);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/organisation/Controller/OrganisationController.java
+++ b/src/main/java/hng_java_boilerplate/organisation/Controller/OrganisationController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/api/organisations")
+@RequestMapping("/api/v1/organisations")
 public class OrganisationController {
     @Autowired
     private OrganisationService organisationService;

--- a/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
+++ b/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
@@ -8,16 +8,18 @@ import hng_java_boilerplate.organisation.entity.Organisation;
 import hng_java_boilerplate.organisation.repository.OrganisationRepository;
 import hng_java_boilerplate.user.entity.User;
 import hng_java_boilerplate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 
+@RequiredArgsConstructor
 public class OrganisationService {
 
-    @Autowired
-    private OrganisationRepository organisationRepository;
 
-    @Autowired
-    private UserRepository userService;
+    private final OrganisationRepository organisationRepository;
+
+
+    private final UserRepository userService;
 
 
     public OrganisationResponseDto addUserToOrganisation(String orgId, AddUserToOrganisationRequestDto request, Authentication authentication) {

--- a/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
+++ b/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
@@ -1,0 +1,39 @@
+package hng_java_boilerplate.organisation.ServiceImpl;
+
+import hng_java_boilerplate.exception.OrganisationNotFoundException;
+import hng_java_boilerplate.exception.UserNotFoundException;
+import hng_java_boilerplate.organisation.dto.AddUserToOrganisationRequestDto;
+import hng_java_boilerplate.organisation.dto.OrganisationResponseDto;
+import hng_java_boilerplate.organisation.entity.Organisation;
+import hng_java_boilerplate.organisation.repository.OrganisationRepository;
+import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+
+public class OrganisationService {
+
+    @Autowired
+    private OrganisationRepository organisationRepository;
+
+    @Autowired
+    private UserRepository userService;
+
+
+    public OrganisationResponseDto addUserToOrganisation(String orgId, AddUserToOrganisationRequestDto request, Authentication authentication) {
+        User currentUser = userService.findByEmail(authentication.getName())
+                .orElseThrow(UserNotFoundException::new);
+
+        Organisation organisation = organisationRepository.findById(orgId)
+                .orElseThrow(OrganisationNotFoundException::new);
+
+        User userToAdd = userService.findById(currentUser.getId())
+                .orElseThrow(UserNotFoundException::new);
+
+        organisation.getUsers().add(userToAdd);
+        organisationRepository.save(organisation);
+
+        return new OrganisationResponseDto("success", "User added to organisation successfully", null);
+    }
+
+}

--- a/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
+++ b/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
@@ -1,12 +1,14 @@
 package hng_java_boilerplate.organisation.ServiceImpl;
 
 import hng_java_boilerplate.exception.OrganisationNotFoundException;
+import hng_java_boilerplate.exception.UserAlreadyAssignedException;
 import hng_java_boilerplate.exception.UserNotFoundException;
 import hng_java_boilerplate.organisation.dto.AddUserToOrganisationRequestDto;
 import hng_java_boilerplate.organisation.dto.OrganisationResponseDto;
 import hng_java_boilerplate.organisation.entity.Organisation;
 import hng_java_boilerplate.organisation.repository.OrganisationRepository;
 import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.exception.InvalidRequestException;
 import hng_java_boilerplate.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,8 +31,16 @@ public class OrganisationService {
         Organisation organisation = organisationRepository.findById(orgId)
                 .orElseThrow(OrganisationNotFoundException::new);
 
+        if (request.getUserId() == null || request.getUserId().isEmpty()) {
+            throw new InvalidRequestException("User ID is required.");
+        }
+
         User userToAdd = userService.findById(currentUser.getId())
                 .orElseThrow(UserNotFoundException::new);
+
+        if (organisation.getUsers().contains(userToAdd)) {
+            throw new UserAlreadyAssignedException("User is already assigned to the organisation.");
+        }
 
         organisation.getUsers().add(userToAdd);
         organisationRepository.save(organisation);

--- a/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
+++ b/src/main/java/hng_java_boilerplate/organisation/ServiceImpl/OrganisationService.java
@@ -1,6 +1,7 @@
 package hng_java_boilerplate.organisation.ServiceImpl;
 
 import hng_java_boilerplate.exception.OrganisationNotFoundException;
+import hng_java_boilerplate.exception.UnauthorizedAccessException;
 import hng_java_boilerplate.exception.UserAlreadyAssignedException;
 import hng_java_boilerplate.exception.UserNotFoundException;
 import hng_java_boilerplate.organisation.dto.AddUserToOrganisationRequestDto;
@@ -8,6 +9,7 @@ import hng_java_boilerplate.organisation.dto.OrganisationResponseDto;
 import hng_java_boilerplate.organisation.entity.Organisation;
 import hng_java_boilerplate.organisation.repository.OrganisationRepository;
 import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.enums.Role;
 import hng_java_boilerplate.user.exception.InvalidRequestException;
 import hng_java_boilerplate.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,8 @@ public class OrganisationService {
 
 
     private final OrganisationRepository organisationRepository;
+
+    private final Role role;
 
 
     private final UserRepository userService;
@@ -40,6 +44,10 @@ public class OrganisationService {
 
         if (organisation.getUsers().contains(userToAdd)) {
             throw new UserAlreadyAssignedException("User is already assigned to the organisation.");
+        }
+
+        if (!currentUser.getUserRole().equals(Role.ROLE_ADMIN) || !currentUser.getUserRole().equals(Role.ROLE_SUPER_ADMIN)) {
+            throw new UnauthorizedAccessException("You are not authorized to add users to this organisation.");
         }
 
         organisation.getUsers().add(userToAdd);

--- a/src/main/java/hng_java_boilerplate/organisation/dto/AddUserToOrganisationRequestDto.java
+++ b/src/main/java/hng_java_boilerplate/organisation/dto/AddUserToOrganisationRequestDto.java
@@ -1,0 +1,15 @@
+package hng_java_boilerplate.organisation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddUserToOrganisationRequestDto {
+
+    @NotBlank(message = "User ID is required")
+    private String userId;
+}

--- a/src/main/java/hng_java_boilerplate/organisation/dto/OrganisationData.java
+++ b/src/main/java/hng_java_boilerplate/organisation/dto/OrganisationData.java
@@ -1,0 +1,16 @@
+package hng_java_boilerplate.organisation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrganisationData {
+
+    private List<OrganisationDetail> organisations;
+
+}

--- a/src/main/java/hng_java_boilerplate/organisation/dto/OrganisationDetail.java
+++ b/src/main/java/hng_java_boilerplate/organisation/dto/OrganisationDetail.java
@@ -1,0 +1,14 @@
+package hng_java_boilerplate.organisation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrganisationDetail {
+    private String orgId;
+    private String name;
+    private String description;
+}

--- a/src/main/java/hng_java_boilerplate/organisation/dto/OrganisationResponseDto.java
+++ b/src/main/java/hng_java_boilerplate/organisation/dto/OrganisationResponseDto.java
@@ -1,0 +1,18 @@
+package hng_java_boilerplate.organisation.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganisationResponseDto {
+
+    private String status;
+    private String message;
+    private OrganisationData data;
+
+}

--- a/src/main/java/hng_java_boilerplate/user/enums/Role.java
+++ b/src/main/java/hng_java_boilerplate/user/enums/Role.java
@@ -1,5 +1,5 @@
 package hng_java_boilerplate.user.enums;
 
 public enum Role {
-    ROLE_USER, ROLE_ADMIN
+    ROLE_USER, ROLE_ADMIN, ROLE_SUPER_ADMIN
 }

--- a/src/test/java/hng_java_boilerplate/addUserToOrganisation_Test/OrganisationServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/addUserToOrganisation_Test/OrganisationServiceTest.java
@@ -3,14 +3,17 @@ package hng_java_boilerplate.addUserToOrganisation_Test;
 import hng_java_boilerplate.exception.OrganisationNotFoundException;
 import hng_java_boilerplate.exception.UserAlreadyAssignedException;
 import hng_java_boilerplate.exception.UserNotFoundException;
+import hng_java_boilerplate.exception.UnauthorizedAccessException;
 import hng_java_boilerplate.organisation.ServiceImpl.OrganisationService;
 import hng_java_boilerplate.organisation.dto.AddUserToOrganisationRequestDto;
 import hng_java_boilerplate.organisation.dto.OrganisationResponseDto;
 import hng_java_boilerplate.organisation.entity.Organisation;
 import hng_java_boilerplate.organisation.repository.OrganisationRepository;
 import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.enums.Role;
 import hng_java_boilerplate.user.exception.InvalidRequestException;
 import hng_java_boilerplate.user.repository.UserRepository;
+import hng_java_boilerplate.user.entity.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -47,17 +50,21 @@ public class OrganisationServiceTest {
         User currentUser = new User();
         currentUser.setId("user123");
         currentUser.setEmail("user@example.com");
+        currentUser.setUserRole(Role.ROLE_ADMIN);
 
         Organisation organisation = new Organisation();
         organisation.setId(orgId);
         organisation.setUsers(new HashSet<>());
 
+        User userToAdd = new User();
+        userToAdd.setId("userToAdd123");
+
         AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
-        requestDto.setUserId("user123");
+        requestDto.setUserId("userToAdd123");
 
         when(authentication.getName()).thenReturn("user@example.com");
         when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(currentUser));
-        when(userRepository.findById("user123")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById("userToAdd123")).thenReturn(Optional.of(userToAdd));
         when(organisationRepository.findById(orgId)).thenReturn(Optional.of(organisation));
         when(organisationRepository.save(organisation)).thenReturn(organisation);
 
@@ -74,7 +81,7 @@ public class OrganisationServiceTest {
         // Arrange
         String orgId = "org123";
         AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
-        requestDto.setUserId("user123");
+        requestDto.setUserId("userToAdd123");
 
         when(authentication.getName()).thenReturn("user@example.com");
         when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.empty());
@@ -94,11 +101,11 @@ public class OrganisationServiceTest {
 
         when(authentication.getName()).thenReturn("user@example.com");
         when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(currentUser));
-        when(userRepository.findById("user123")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById("userToAdd123")).thenReturn(Optional.of(new User()));
         when(organisationRepository.findById(orgId)).thenReturn(Optional.empty());
 
         AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
-        requestDto.setUserId("user123");
+        requestDto.setUserId("userToAdd123");
 
         // Act & Assert
         assertThrows(OrganisationNotFoundException.class, () ->
@@ -131,23 +138,57 @@ public class OrganisationServiceTest {
         User currentUser = new User();
         currentUser.setId("user123");
         currentUser.setEmail("user@example.com");
+        currentUser.setUserRole(Role.ROLE_ADMIN);
 
         Organisation organisation = new Organisation();
         organisation.setId(orgId);
         organisation.setUsers(new HashSet<>());
 
-        organisation.getUsers().add(currentUser);
+        User userToAdd = new User();
+        userToAdd.setId("userToAdd123");
+
+        organisation.getUsers().add(userToAdd);
 
         AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
-        requestDto.setUserId("user123");
+        requestDto.setUserId("userToAdd123");
 
         when(authentication.getName()).thenReturn("user@example.com");
         when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(currentUser));
-        when(userRepository.findById("user123")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById("userToAdd123")).thenReturn(Optional.of(userToAdd));
         when(organisationRepository.findById(orgId)).thenReturn(Optional.of(organisation));
 
         // Act & Assert
         assertThrows(UserAlreadyAssignedException.class, () ->
+                organisationService.addUserToOrganisation(orgId, requestDto, authentication)
+        );
+    }
+
+    @Test
+    public void testAddUserToOrganisation_UnauthorizedAccess() {
+        // Arrange
+        String orgId = "org123";
+        User currentUser = new User();
+        currentUser.setId("user123");
+        currentUser.setEmail("user@example.com");
+        currentUser.setUserRole(Role.ROLE_USER); // Not an admin or super admin
+
+        Organisation organisation = new Organisation();
+        organisation.setId(orgId);
+        organisation.setUsers(new HashSet<>());
+
+        User userToAdd = new User();
+        userToAdd.setId("userToAdd123");
+
+        AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
+        requestDto.setUserId("userToAdd123");
+
+        when(authentication.getName()).thenReturn("user@example.com");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById("userToAdd123")).thenReturn(Optional.of(userToAdd));
+        when(organisationRepository.findById(orgId)).thenReturn(Optional.of(organisation));
+
+        // Act & Assert
+        assertThrows(UnauthorizedAccessException.class, () ->
                 organisationService.addUserToOrganisation(orgId, requestDto, authentication)
         );
     }

--- a/src/test/java/hng_java_boilerplate/addUserToOrganisation_Test/addUsers_unitTest.java
+++ b/src/test/java/hng_java_boilerplate/addUserToOrganisation_Test/addUsers_unitTest.java
@@ -1,0 +1,103 @@
+package hng_java_boilerplate.addUserToOrganisation_Test;
+
+import hng_java_boilerplate.exception.OrganisationNotFoundException;
+import hng_java_boilerplate.exception.UserNotFoundException;
+import hng_java_boilerplate.organisation.ServiceImpl.OrganisationService;
+import hng_java_boilerplate.organisation.dto.AddUserToOrganisationRequestDto;
+import hng_java_boilerplate.organisation.dto.OrganisationResponseDto;
+import hng_java_boilerplate.organisation.entity.Organisation;
+import hng_java_boilerplate.organisation.repository.OrganisationRepository;
+import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OrganisationServiceTest {
+
+    @InjectMocks
+    private OrganisationService organisationService;
+
+    @Mock
+    private OrganisationRepository organisationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @Test
+    public void testAddUserToOrganisation_Success() {
+        // Arrange
+        String orgId = "org123";
+        User currentUser = new User();
+        currentUser.setId("user123");
+        currentUser.setEmail("user@example.com");
+
+        Organisation organisation = new Organisation();
+        organisation.setId(orgId);
+        organisation.setUsers(new HashSet<>());
+
+        AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
+
+        when(authentication.getName()).thenReturn("user@example.com");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById("user123")).thenReturn(Optional.of(currentUser));
+        when(organisationRepository.findById(orgId)).thenReturn(Optional.of(organisation));
+        when(organisationRepository.save(organisation)).thenReturn(organisation);
+
+        // Act
+        OrganisationResponseDto response = organisationService.addUserToOrganisation(orgId, requestDto, authentication);
+
+        // Assert
+        assertEquals("success", response.getStatus());
+        assertEquals("User added to organisation successfully", response.getMessage());
+    }
+
+    @Test
+    public void testAddUserToOrganisation_UserNotFound() {
+        // Arrange
+        String orgId = "org123";
+        AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
+
+        when(authentication.getName()).thenReturn("user@example.com");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(UserNotFoundException.class, () ->
+                organisationService.addUserToOrganisation(orgId, requestDto, authentication)
+        );
+    }
+
+    @Test
+    public void testAddUserToOrganisation_OrganisationNotFound() {
+        // Arrange
+        String orgId = "org123";
+        User currentUser = new User();
+        currentUser.setId("user123");
+
+        when(authentication.getName()).thenReturn("user@example.com");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById("user123")).thenReturn(Optional.of(currentUser));
+        when(organisationRepository.findById(orgId)).thenReturn(Optional.empty());
+
+        AddUserToOrganisationRequestDto requestDto = new AddUserToOrganisationRequestDto();
+
+        // Act & Assert
+        assertThrows(OrganisationNotFoundException.class, () ->
+                organisationService.addUserToOrganisation(orgId, requestDto, authentication)
+        );
+    }
+}


### PR DESCRIPTION
How should this be manually tested?
Try;
-adding a non-existent user
-adding a user that belongs to the organization already
-adding a user to an organization that doesn't exist

 Checklist of what you did:
- ensured only authenticated users can go through (admins/super_admins can access)
- implemented the logic to ensure organization user belongs to exist before adding.
- implemented the logic to ensure admin doesn't create a duplicate of the user
