### PR TITLE
feat:Delete product feature

### DIFF
--- a/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
+++ b/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package hng_java_boilerplate.config;
 
+import hng_java_boilerplate.user.enums.Role;
 import hng_java_boilerplate.user.serviceImpl.UserServiceImpl;
 import hng_java_boilerplate.util.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,6 +72,7 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(httpRequests ->
                         httpRequests
+                                .requestMatchers("/api/v1/products/{id}").hasAuthority(String.valueOf(Role.ROLE_ADMIN))
                                 .requestMatchers(
                                         "/",
                                         "/docs",

--- a/src/main/java/hng_java_boilerplate/product/controller/ProductController.java
+++ b/src/main/java/hng_java_boilerplate/product/controller/ProductController.java
@@ -1,7 +1,10 @@
 package hng_java_boilerplate.product.controller;
 
+import hng_java_boilerplate.product.dto.ProductErrorDTO;
 import hng_java_boilerplate.product.dto.ProductSearchDTO;
 import hng_java_boilerplate.product.entity.Product;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
 import hng_java_boilerplate.product.product_mapper.ProductMapper;
 import hng_java_boilerplate.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -60,5 +60,21 @@ public class ProductController {
         productSearchDTO.setPage(products.getNumber());
         productSearchDTO.setSuccess(true);
         return new ResponseEntity<>(productSearchDTO, HttpStatus.OK);
+    }
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteProductById(@PathVariable String id){
+        try{
+            productService.deleteProductById(id);
+            return ResponseEntity.noContent().build();
+        }catch (ProductNotFoundException e){
+            ProductErrorDTO errorDTO = new ProductErrorDTO(false,"Product not found",HttpStatus.NOT_FOUND.value());
+            return new ResponseEntity<>(errorDTO, HttpStatus.NOT_FOUND);
+        }catch (UnauthorizedAccessException e){
+            ProductErrorDTO errorDTO = new ProductErrorDTO(false,"You do not have permission to delete this product",HttpStatus.FORBIDDEN.value());
+            return new ResponseEntity<>(errorDTO, HttpStatus.FORBIDDEN);
+        }catch (Exception e){
+            ProductErrorDTO errorDTO = new ProductErrorDTO(false,"Internal server error",HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return new ResponseEntity<>(errorDTO, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/hng_java_boilerplate/product/exceptions/ProductNotFoundException.java
+++ b/src/main/java/hng_java_boilerplate/product/exceptions/ProductNotFoundException.java
@@ -1,0 +1,7 @@
+package hng_java_boilerplate.product.exceptions;
+
+public class ProductNotFoundException extends RuntimeException{
+    public ProductNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/product/exceptions/UnauthorizedAccessException.java
+++ b/src/main/java/hng_java_boilerplate/product/exceptions/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package hng_java_boilerplate.product.exceptions;
+
+public class UnauthorizedAccessException extends RuntimeException{
+    public UnauthorizedAccessException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/hng_java_boilerplate/product/service/ProductService.java
+++ b/src/main/java/hng_java_boilerplate/product/service/ProductService.java
@@ -1,6 +1,8 @@
 package hng_java_boilerplate.product.service;
 
 import hng_java_boilerplate.product.entity.Product;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +12,6 @@ public interface ProductService {
 
     //Method to Search for products with certain criteria, returns a list of products
     Page<Product> productsSearch(String name, String category, Double minPrice, Double maxPrice, Pageable pageable);
+    void deleteProductById(String id) throws ProductNotFoundException, UnauthorizedAccessException;
+
 }

--- a/src/main/java/hng_java_boilerplate/product/service/ProductServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/product/service/ProductServiceImpl.java
@@ -4,10 +4,15 @@ import hng_java_boilerplate.product.dto.ErrorDTO;
 import hng_java_boilerplate.product.entity.Product;
 import hng_java_boilerplate.product.exceptions.ValidationError;
 import hng_java_boilerplate.product.repository.ProductRepository;
+import hng_java_boilerplate.user.enums.Role;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import java.util.List;
 
 @Service
 
@@ -28,5 +33,26 @@ public class ProductServiceImpl implements ProductService{
             throw new ValidationError(errorDTO);
         }
         return productRepository.searchProducts(name, category, minPrice, maxPrice, pageable);
+    }
+
+    @Override
+    public void deleteProductById(String id) throws ProductNotFoundException, UnauthorizedAccessException {
+        Product product = productRepository.findById(id).orElseThrow(() -> new ProductNotFoundException("Product not found"));
+        if (!hasPermissionToDelete(product)){
+            throw new UnauthorizedAccessException("You do not have permission to delete this product");
+        }
+        productRepository.delete(product);
+    }
+    private boolean hasPermissionToDelete(Product product){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()){
+            for (GrantedAuthority authority : authentication.getAuthorities()){
+                Role role = Role.valueOf(authority.getAuthority().replace("ROLE_",""));
+                if (role == Role.ROLE_ADMIN){
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/hng_java_boilerplate/product_test/unit_test/ProductDeleteTest.java
+++ b/src/test/java/hng_java_boilerplate/product_test/unit_test/ProductDeleteTest.java
@@ -1,0 +1,44 @@
+package hng_java_boilerplate.product_test.unit_test;
+
+import hng_java_boilerplate.product.entity.Product;
+import hng_java_boilerplate.product.exceptions.ProductNotFoundException;
+import hng_java_boilerplate.product.exceptions.UnauthorizedAccessException;
+import hng_java_boilerplate.product.repository.ProductRepository;
+import hng_java_boilerplate.product.service.ProductServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class ProductDeleteTest {
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductServiceImpl productService;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+    }
+    @Test
+    public void testDeleteProduct_ProductNotFound_ThrowsProductNotFoundException(){
+        String productId = "invalidProductId";
+        doReturn(java.util.Optional.empty()).when(productRepository).findById(productId);
+        ProductNotFoundException thrown = assertThrows(ProductNotFoundException.class, () ->{
+            productService.deleteProductById(productId);
+        });
+        assertEquals("Product not found", thrown.getMessage());
+    }
+}


### PR DESCRIPTION
### Implemented Product Deletion Endpoint

This pull request adds the DELETE `/api/v1/products/:productId` endpoint to remove a specific product.

#### Manual Testing Instructions:

1. **Access with a valid `productId`:**
   - **Endpoint:** `DELETE /api/v1/products/validProductId`
   - **Expected Response:**
     - Status code: `204 No Content`
     - The product is successfully deleted, and no content is returned.

2. **Access with an invalid `productId`:**
   - **Endpoint:** `DELETE /api/v1/products/invalidProductId`
   - **Expected Response:**
     ```json
     {
       "statusCode": 404,
       "message": "Product not found"
     }
     ```

3. **Access without proper authorization:**
   - **Endpoint:** `DELETE /api/v1/products/productIdWithoutPermission`
   - **Expected Response:**
     ```json
     {
       "statusCode": 403,
       "message": "You do not have permission to delete this product"
     }
     ```

#### Checklist of Changes:

- Implemented the DELETE `/api/v1/products/:productId` endpoint.
- Added logic to check user permissions before deleting a product.
- Implemented error handling for scenarios where the product does not exist or the user lacks the necessary permissions.

#### Reference Issue:

[FEAT]: Endpoint for Product Deletion (#284)

Link to the issue: [https://github.com/hngprojects/hng_boilerplate_java_web/issues/14](https://github.com/hngprojects/hng_boilerplate_java_web/issues/14)