### PR TITLE
Feat: Added Prometheus for metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,14 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>

--- a/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
+++ b/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
@@ -79,7 +79,7 @@ public class WebSecurityConfig {
                                         "/api/v1/products/search",
                                         "/swagger-ui/index.html",
                                         "/swagger-resources/**",
-                                        "/webjars/**",
+                                        "/webjars/**","/metrics",
                                         "/swagger-ui/**",
                                         "/api/v1/auth/**",
                                         "/api/v1/waitlist"

--- a/src/main/java/hng_java_boilerplate/metrics/MetricController.java
+++ b/src/main/java/hng_java_boilerplate/metrics/MetricController.java
@@ -1,0 +1,20 @@
+package hng_java_boilerplate;
+
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/metrics")
+public class MetricController {
+
+    @Autowired
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+
+    @GetMapping
+    public String getMetrics() {
+        return prometheusMeterRegistry.scrape();
+    }
+}


### PR DESCRIPTION


### **How should this be manually tested?**

1. **Access the Metrics Endpoint:**
   - Ensure your Spring Boot application is running.
   - Open a browser or use `curl` to access the `/metrics` endpoint:
     ```
     curl http://localhost:8080/metrics
     ```
   - Verify that Prometheus-formatted metrics are displayed.

### **Checklist of what I did**

- [x] Prometheus metrics must be available at the `/metrics` endpoint.
- [x] Spring Boot configuration must include the `micrometer-registry-prometheus` dependency.
- [x] Prometheus must be configured to scrape metrics from the `/metrics` endpoint.

### **Reference Issue**
[issue 208](https://github.com/hngprojects/hng_boilerplate_java_web/issues/208)