### PR TITLE
Feat: Added Prometheus for metrics

### DIFF
--- a/src/main/java/hng_java_boilerplate/metrics/MetricController.java
+++ b/src/main/java/hng_java_boilerplate/metrics/MetricController.java
@@ -1,0 +1,21 @@
+package hng_java_boilerplate.metrics;
+
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/metrics")
+@RequiredArgsConstructor
+public class MetricController {
+
+    private final PrometheusMeterRegistry prometheusMeterRegistry;
+
+    @GetMapping
+    public String getMetrics() {
+        return prometheusMeterRegistry.scrape();
+    }
+}


### PR DESCRIPTION

### **How should this be manually tested?**

1. **Access the Metrics Endpoint:**
   - Ensure your Spring Boot application is running.
   - Open a browser or use `curl` to access the `/metrics` endpoint:
     ```
     curl http://localhost:8080/metrics
     ```
   - Verify that Prometheus-formatted metrics are displayed.

### **Checklist of what I did**

- [x] Prometheus metrics must be available at the `/metrics` endpoint.
- [x] Spring Boot configuration must include the `micrometer-registry-prometheus` dependency.
- [x] Prometheus must be configured to scrape metrics from the `/metrics` endpoint.

### **Reference Issue**
[issue 208](https://github.com/hngprojects/hng_boilerplate_java_web/issues/208)