### PR TITLE
Feat: Added Prometheus for metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 
 ../hng_boilerplate_java_web2/src/main/java/hng_java_boilerplate/utils/application.properties
 
+src/main/resources/application.properties

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
+			<version>1.10.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>

--- a/src/main/java/hng_java_boilerplate/config/MetricsConfig.java
+++ b/src/main/java/hng_java_boilerplate/config/MetricsConfig.java
@@ -1,0 +1,15 @@
+package hng_java_boilerplate.config;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public PrometheusMeterRegistry prometheusMeterRegistry() {
+        return new PrometheusMeterRegistry(io.micrometer.prometheus.PrometheusConfig.DEFAULT);
+    }
+
+}

--- a/src/main/java/hng_java_boilerplate/metrics/MetricsController.java
+++ b/src/main/java/hng_java_boilerplate/metrics/MetricsController.java
@@ -1,0 +1,20 @@
+package hng_java_boilerplate.metrics;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/metrics")
+@RequiredArgsConstructor
+public class MetricsController {
+
+    private final PrometheusMeterRegistry prometheusMeterRegistry;
+
+    @GetMapping
+    public String getMetrics(){
+        return prometheusMeterRegistry.scrape();
+    }
+}


### PR DESCRIPTION
### **How should this be manually tested?**

1. **Access the Metrics Endpoint:**
   - Ensure your Spring Boot application is running.
   - Open a browser or use `curl` to access the `/metrics` endpoint:
     ```
     curl http://localhost:8080/metrics
     ```
   - Verify that Prometheus-formatted metrics are displayed.

### **Checklist of what I did**

- [x] Prometheus metrics must be available at the `/metrics` endpoint.
- [x] Spring Boot configuration must include the `micrometer-registry-prometheus` dependency.
- [x] Prometheus must be configured to scrape metrics from the `/metrics` endpoint.

### **Reference Issue**
[issue 208](https://github.com/hngprojects/hng_boilerplate_java_web/issues/208)