### PR TITLE
[Fix] : Configure Public Access for Swagger UI and API Documentation Endpoints

### DIFF
--- a/src/main/java/hng_java_boilerplate/config/SwaggerConfig.java
+++ b/src/main/java/hng_java_boilerplate/config/SwaggerConfig.java
@@ -1,0 +1,57 @@
+package hng_java_boilerplate.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+public class SwaggerConfig{
+
+    @Bean
+    public GroupedOpenApi publicApi(){
+        return GroupedOpenApi.builder()
+                .group("public")
+                .pathsToMatch("/api/v1/**")
+                .build();
+    }
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("BoilerPlate").version("1.0")
+                        .description("A standardized and reusable set of code " +
+                                "used as a starting point for developing applications"))
+                .servers(Arrays.asList(
+                        new Server().url("https://api-java.boilerplate.hng.tech").description("My App Server URL"),
+                        new Server().url("http://localhost:8080").description("Local server"),
+                        new Server().url("https://deployment.api-java.boilerplate.hng.tech").description("My App " +
+                                "deployment Server URL"),
+                        new Server().url("https://staging.api-java.boilerplate.hng.tech").description("My App Server URL")
+
+
+
+                        ))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .name("bearerAuth")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                        ))
+                .security(Collections.singletonList(
+                        new SecurityRequirement().addList("bearerAuth")
+                ));
+
+    }
+}

--- a/src/main/java/hng_java_boilerplate/helpCenter/contactUs/controller/ContactUsController.java
+++ b/src/main/java/hng_java_boilerplate/helpCenter/contactUs/controller/ContactUsController.java
@@ -3,6 +3,7 @@ package hng_java_boilerplate.helpCenter.contactUs.controller;
 import hng_java_boilerplate.helpCenter.contactUs.dto.request.ContactUsRequest;
 import hng_java_boilerplate.helpCenter.contactUs.dto.response.CustomResponse;
 import hng_java_boilerplate.helpCenter.contactUs.service.ContactUsService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/contacts")
+@Tag(name = "Contact Us")
 public class ContactUsController {
     private final ContactUsService contactUsService;
 

--- a/src/main/java/hng_java_boilerplate/helpCenter/faq/controller/FaqController.java
+++ b/src/main/java/hng_java_boilerplate/helpCenter/faq/controller/FaqController.java
@@ -4,6 +4,7 @@ import hng_java_boilerplate.helpCenter.faq.dto.request.FaqRequest;
 import hng_java_boilerplate.helpCenter.faq.dto.response.CustomResponse;
 import hng_java_boilerplate.helpCenter.faq.dto.response.FaqResponse;
 import hng_java_boilerplate.helpCenter.faq.service.FaqService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/faqs")
+@Tag(name="Faq")
 public class FaqController {
     private final FaqService faqService;
 

--- a/src/main/java/hng_java_boilerplate/metrics/MetricsController.java
+++ b/src/main/java/hng_java_boilerplate/metrics/MetricsController.java
@@ -2,6 +2,8 @@ package hng_java_boilerplate.metrics;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/hng_java_boilerplate/metrics/MetricsController.java
+++ b/src/main/java/hng_java_boilerplate/metrics/MetricsController.java
@@ -1,6 +1,7 @@
 package hng_java_boilerplate.metrics;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/metrics")
+@Hidden
 public class MetricsController {
 
     private final PrometheusMeterRegistry prometheusMeterRegistry;

--- a/src/main/java/hng_java_boilerplate/organisation/controller/OrganisationController.java
+++ b/src/main/java/hng_java_boilerplate/organisation/controller/OrganisationController.java
@@ -3,6 +3,7 @@ package hng_java_boilerplate.organisation.controller;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationRequestDto;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationResponseDto;
 import hng_java_boilerplate.organisation.service.OrganisationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/organisations")
+@Tag(name="Organisation")
 public class OrganisationController {
     private final OrganisationService organisationService;
 

--- a/src/main/java/hng_java_boilerplate/plans/controller/PlanController.java
+++ b/src/main/java/hng_java_boilerplate/plans/controller/PlanController.java
@@ -4,6 +4,7 @@ import hng_java_boilerplate.plans.dtos.CreatePlanDto;
 import hng_java_boilerplate.plans.dtos.PlanResponse;
 import hng_java_boilerplate.plans.entity.Plan;
 import hng_java_boilerplate.plans.service.PlanService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import java.util.List;
 @RestController
 @RequestMapping("api/v1/plans")
 @RequiredArgsConstructor
+@Tag(name="Plans")
 public class PlanController {
 
     private final PlanService planService;

--- a/src/main/java/hng_java_boilerplate/product/controller/ProductController.java
+++ b/src/main/java/hng_java_boilerplate/product/controller/ProductController.java
@@ -4,6 +4,7 @@ import hng_java_boilerplate.product.dto.ProductSearchDTO;
 import hng_java_boilerplate.product.entity.Product;
 import hng_java_boilerplate.product.product_mapper.ProductMapper;
 import hng_java_boilerplate.product.service.ProductService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/products")
+@Tag(name="Product")
 public class ProductController {
 
     private final ProductService productService;

--- a/src/main/java/hng_java_boilerplate/profile/controller/ProfileController.java
+++ b/src/main/java/hng_java_boilerplate/profile/controller/ProfileController.java
@@ -3,6 +3,7 @@ package hng_java_boilerplate.profile.controller;
 import hng_java_boilerplate.profile.dto.request.DeactivateUserRequest;
 import hng_java_boilerplate.profile.dto.response.DeactivateUserResponse;
 import hng_java_boilerplate.profile.service.ProfileService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/accounts")
+@Tag(name="Profiles")
 public class ProfileController {
     private final ProfileService profileService;
 

--- a/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeRequestController.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeRequestController.java
@@ -5,6 +5,7 @@ import hng_java_boilerplate.squeeze.entity.SqueezeRequest;
 import hng_java_boilerplate.squeeze.exceptions.DuplicateEmailException;
 import hng_java_boilerplate.squeeze.service.SqueezeRequestService;
 import hng_java_boilerplate.squeeze.dto.ResponseMessageDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ import java.util.NoSuchElementException;
 @RequestMapping("/api/v1/squeeze")
 @Validated
 @RequiredArgsConstructor
+@Tag(name="Squeeze")
 public class SqueezeRequestController {
 
     private final SqueezeRequestService service;

--- a/src/main/java/hng_java_boilerplate/user/controller/AuthController.java
+++ b/src/main/java/hng_java_boilerplate/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
 import hng_java_boilerplate.user.entity.User;
 import hng_java_boilerplate.user.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Tag(name="Authentication")
 public class AuthController {
 
     private final UserService userService;

--- a/src/main/java/hng_java_boilerplate/user/controller/UserController.java
+++ b/src/main/java/hng_java_boilerplate/user/controller/UserController.java
@@ -2,6 +2,7 @@ package hng_java_boilerplate.user.controller;
 
 import hng_java_boilerplate.user.service.UserService;
 import hng_java_boilerplate.user.serviceImpl.UserServiceImpl;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import javax.crypto.BadPaddingException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
+@Tag(name="Users")
 public class UserController {
     private final UserService userService;
 

--- a/src/main/java/hng_java_boilerplate/waitlist/controller/WaitlistController.java
+++ b/src/main/java/hng_java_boilerplate/waitlist/controller/WaitlistController.java
@@ -3,6 +3,7 @@ package hng_java_boilerplate.waitlist.controller;
 import hng_java_boilerplate.email.EmailServices.EmailProducerService;
 import hng_java_boilerplate.waitlist.entity.Waitlist;
 import hng_java_boilerplate.waitlist.service.WaitlistService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("api/v1/waitlist")
+@Tag(name="Waitlist")
 public class WaitlistController {
 
     private final WaitlistService waitlistService;


### PR DESCRIPTION
**How should this be manually tested:**

1. **Access Swagger UI:**
   - Navigate to `http://localhost:8080/docs` in your web browser.
   - Verify that the Swagger UI loads correctly and is fully interactive.

2. **Check API Documentation:**
   - Visit `http://localhost:8080/v3/api-docs` ` to ensure that the API documentation is visible and accessible.

3. **Verify Swagger Resources:**
   - Ensure that resources at `/swagger-resources/**`, `/webjars/**`, and `/swagger-ui/**` are accessible without authentication.

4. **Confirm Authentication Protection:**
   - Test other API endpoints to ensure that they still require authentication where necessary, especially endpoints under `/api/v1/auth/logout` and `/api/**`.

**Checklist of what I did:**

- [x] Configured `.requestMatchers()` to permit all users to access:
  - Swagger UI home page:  `/docs` , `/swagger-ui/index.html`
  - API documentation: `/v3/api-docs/**`, `/v3/api-docs`
  - Swagger resources: `/swagger-resources/**`, `/webjars/**`, `/swagger-ui/**`
- [x] Ensured that other sensitive API endpoints are protected and require authentication.
- [x] Verified that changes do not affect existing authentication requirements for protected endpoints.

**Reference Issue:**
[Configure Public Access for Swagger UI and API Documentation Endpoints](https://github.com/hngprojects/hng_boilerplate_java_web/issues/170)