### PR TITLE
feat: Squeeze Config Pages

### DIFF
--- a/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeConfigController.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeConfigController.java
@@ -1,4 +1,100 @@
 package hng_java_boilerplate.squeeze.controller;
 
+import hng_java_boilerplate.squeeze.entity.SqueezeConfig;
+import hng_java_boilerplate.squeeze.service.SqueezeConfigService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/squeeze/config")
+@Tag(name = "Squeeze Pages")
+@PreAuthorize("hasRole('ADMIN')")
 public class SqueezeConfigController {
+
+    private final SqueezeConfigService squeezeConfigService;
+
+    public SqueezeConfigController(SqueezeConfigService squeezeConfigService) {
+        this.squeezeConfigService = squeezeConfigService;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createSqueezePage(@RequestBody SqueezeConfig squeezeConfig) throws IOException, SQLException {
+        SqueezeConfig savedPage = squeezeConfigService.createSqueezePage(squeezeConfig);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "Squeeze config page created successfully");
+        response.put("id", savedPage.getId());
+        response.put("status_code", HttpStatus.CREATED.value());
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getSqueezePages(Pageable pageable) {
+        Page<SqueezeConfig> squeezePages = squeezeConfigService.getSqueezePages(pageable);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("pages", squeezePages.getContent());
+        response.put("current_page", squeezePages.getNumber());
+        response.put("total_items", squeezePages.getTotalElements());
+        response.put("total_pages", squeezePages.getTotalPages());
+        response.put("status_code", HttpStatus.OK.value());
+        response.put("message", "Retrieved squeeze pages successfully");
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchSqueezePages(@RequestParam String keyword, Pageable pageable) {
+        Page<SqueezeConfig> squeezePages = squeezeConfigService.searchSqueezePages(keyword, pageable);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("pages", squeezePages.getContent());
+        response.put("current_page", squeezePages.getNumber());
+        response.put("total_items", squeezePages.getTotalElements());
+        response.put("total_pages", squeezePages.getTotalPages());
+        response.put("status_code", HttpStatus.OK.value());
+        response.put("message", "Search completed successfully");
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PatchMapping("/{id}/toggle-active")
+    public ResponseEntity<?> toggleSqueezePageActive(@PathVariable UUID id) {
+        SqueezeConfig updatedPage = squeezeConfigService.toggleSqueezePageActive(id);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "Squeeze page active status toggled successfully");
+        response.put("id", updatedPage.getId());
+        response.put("active", updatedPage.isActive());
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteSqueezePage(@PathVariable String id) {
+        boolean deleted = squeezeConfigService.deleteSqueezePage(id);
+
+        Map<String, Object> response = new HashMap<>();
+
+        if (deleted) {
+            response.put("message", "Squeeze page deleted successfully");
+            response.put("statusCode", 200);
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } else {
+            response.put("message", "Squeeze page not found");
+            response.put("statusCode", 404);
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeConfigController.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeConfigController.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.squeeze.controller;
+
+public class SqueezeConfigController {
+}

--- a/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeRequestController.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/controller/SqueezeRequestController.java
@@ -14,6 +14,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -55,6 +56,12 @@ public class SqueezeRequestController {
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ResponseMessageDto(e.getMessage(), HttpStatus.FORBIDDEN.value()));
         }
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getAllSqueezeRequests() {
+        List<SqueezeRequest> squeezeRequests = service.getAllSqueezeRequests();
+        return ResponseEntity.ok().body(squeezeRequests);
     }
 
 }

--- a/src/main/java/hng_java_boilerplate/squeeze/entity/SqueezeConfig.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/entity/SqueezeConfig.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.squeeze.entity;
+
+public class SqueezeConfig {
+}

--- a/src/main/java/hng_java_boilerplate/squeeze/entity/SqueezeConfig.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/entity/SqueezeConfig.java
@@ -1,4 +1,46 @@
 package hng_java_boilerplate.squeeze.entity;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class SqueezeConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String pageTitle;
+
+    @Column(nullable = false, unique = true)
+    private String urlSlug;
+
+    @Column(nullable = false)
+    private String headlineText;
+
+    @Column(nullable = false)
+    private String subheadlineText;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String bodyText;
+
+    private boolean active;
+
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @PrePersist
+    protected void onCreate() {
+        createdDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/hng_java_boilerplate/squeeze/repository/SqueezeConfigRepository.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/repository/SqueezeConfigRepository.java
@@ -1,4 +1,12 @@
 package hng_java_boilerplate.squeeze.repository;
 
-public class SqueezeConfigRepository {
+import hng_java_boilerplate.squeeze.entity.SqueezeConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface SqueezeConfigRepository extends JpaRepository<SqueezeConfig, UUID>, JpaSpecificationExecutor<SqueezeConfig> {
 }

--- a/src/main/java/hng_java_boilerplate/squeeze/repository/SqueezeConfigRepository.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/repository/SqueezeConfigRepository.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.squeeze.repository;
+
+public class SqueezeConfigRepository {
+}

--- a/src/main/java/hng_java_boilerplate/squeeze/service/SqueezeConfigService.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/service/SqueezeConfigService.java
@@ -1,4 +1,55 @@
 package hng_java_boilerplate.squeeze.service;
 
+import hng_java_boilerplate.squeeze.entity.SqueezeConfig;
+import hng_java_boilerplate.squeeze.repository.SqueezeConfigRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
 public class SqueezeConfigService {
+
+    private final SqueezeConfigRepository squeezeConfigRepository;
+
+    public SqueezeConfigService(SqueezeConfigRepository squeezeConfigRepository) {
+        this.squeezeConfigRepository = squeezeConfigRepository;
+    }
+
+    public SqueezeConfig createSqueezePage(SqueezeConfig squeezeConfig) {
+        return squeezeConfigRepository.save(squeezeConfig);
+    }
+
+    public Page<SqueezeConfig> getSqueezePages(Pageable pageable) {
+        return squeezeConfigRepository.findAll(pageable);
+    }
+
+    public Page<SqueezeConfig> searchSqueezePages(String keyword, Pageable pageable) {
+        Specification<SqueezeConfig> spec = (root, query, criteriaBuilder) -> {
+            String likePattern = "%" + keyword.toLowerCase() + "%";
+            return criteriaBuilder.or(
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("pageTitle")), likePattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("urlSlug")), likePattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("headlineText")), likePattern)
+            );
+        };
+        return squeezeConfigRepository.findAll(spec, pageable);
+    }
+
+    public SqueezeConfig toggleSqueezePageActive(UUID id) {
+        SqueezeConfig squeezeConfig = squeezeConfigRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Squeeze page not found"));
+        squeezeConfig.setActive(!squeezeConfig.isActive());
+        return squeezeConfigRepository.save(squeezeConfig);
+    }
+
+    public boolean deleteSqueezePage(String id) {
+        if (squeezeConfigRepository.existsById(UUID.fromString(id))) {
+            squeezeConfigRepository.deleteById(UUID.fromString(id));
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/hng_java_boilerplate/squeeze/service/SqueezeConfigService.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/service/SqueezeConfigService.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.squeeze.service;
+
+public class SqueezeConfigService {
+}

--- a/src/main/java/hng_java_boilerplate/squeeze/service/SqueezeRequestService.java
+++ b/src/main/java/hng_java_boilerplate/squeeze/service/SqueezeRequestService.java
@@ -6,6 +6,7 @@ import hng_java_boilerplate.squeeze.repository.SqueezeRequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -41,5 +42,9 @@ public class SqueezeRequestService {
 
         repository.save(existingRequest);
         return existingRequest;
+    }
+
+    public List<SqueezeRequest> getAllSqueezeRequests() {
+        return repository.findAll();
     }
 }

--- a/src/main/resources/db/migration/V20__create_squeeze_config_page_table.sql
+++ b/src/main/resources/db/migration/V20__create_squeeze_config_page_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE squeeze_page (
+CREATE TABLE squeeze_config (
     id UUID PRIMARY KEY,
     page_title VARCHAR(255) NOT NULL,
     url_slug VARCHAR(255) NOT NULL UNIQUE,

--- a/src/main/resources/db/migration/V20__create_squeeze_config_page_table.sql
+++ b/src/main/resources/db/migration/V20__create_squeeze_config_page_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE squeeze_page (
+    id UUID PRIMARY KEY,
+    page_title VARCHAR(255) NOT NULL,
+    url_slug VARCHAR(255) NOT NULL UNIQUE,
+    headline_text VARCHAR(255) NOT NULL,
+    subheadline_text VARCHAR(255) NOT NULL,
+    body_text TEXT NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT false,
+    created_date TIMESTAMP NOT NULL
+);
+
+-- Create an index on url_slug for faster lookups
+CREATE INDEX idx_squeeze_page_url_slug ON squeeze_page(url_slug);
+
+-- Create an index on created_date for sorting
+CREATE INDEX idx_squeeze_page_created_date ON squeeze_page(created_date);

--- a/src/main/resources/db/migration/V20__create_squeeze_config_page_table.sql
+++ b/src/main/resources/db/migration/V20__create_squeeze_config_page_table.sql
@@ -10,7 +10,7 @@ CREATE TABLE squeeze_config (
 );
 
 -- Create an index on url_slug for faster lookups
-CREATE INDEX idx_squeeze_page_url_slug ON squeeze_page(url_slug);
+CREATE INDEX idx_squeeze_page_url_slug ON squeeze_config(url_slug);
 
 -- Create an index on created_date for sorting
-CREATE INDEX idx_squeeze_page_created_date ON squeeze_page(created_date);
+CREATE INDEX idx_squeeze_page_created_date ON squeeze_config(created_date);

--- a/src/test/java/hng_java_boilerplate/squeeze/controller/SqueezeConfigControllerTest.java
+++ b/src/test/java/hng_java_boilerplate/squeeze/controller/SqueezeConfigControllerTest.java
@@ -1,0 +1,140 @@
+package hng_java_boilerplate.squeeze.controller;
+
+import hng_java_boilerplate.squeeze.entity.SqueezeConfig;
+import hng_java_boilerplate.squeeze.service.SqueezeConfigService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class SqueezeConfigControllerTest {
+
+    @Mock
+    private SqueezeConfigService squeezeConfigService;
+
+    @InjectMocks
+    private SqueezeConfigController squeezeConfigController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testCreateSqueezePage() throws IOException, SQLException {
+        SqueezeConfig squeezeConfig = new SqueezeConfig();
+        squeezeConfig.setId(UUID.randomUUID());
+
+        when(squeezeConfigService.createSqueezePage(any(SqueezeConfig.class))).thenReturn(squeezeConfig);
+
+        ResponseEntity<?> response = squeezeConfigController.createSqueezePage(squeezeConfig);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertEquals("Squeeze config page created successfully", responseBody.get("message"));
+        assertEquals(HttpStatus.CREATED.value(), responseBody.get("status_code"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testGetSqueezePages() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<SqueezeConfig> squeezeConfigPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+        when(squeezeConfigService.getSqueezePages(pageable)).thenReturn(squeezeConfigPage);
+
+        ResponseEntity<?> response = squeezeConfigController.getSqueezePages(pageable);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertEquals("Retrieved squeeze pages successfully", responseBody.get("message"));
+        assertEquals(HttpStatus.OK.value(), responseBody.get("status_code"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testSearchSqueezePages() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<SqueezeConfig> squeezeConfigPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+        when(squeezeConfigService.searchSqueezePages(anyString(), any(Pageable.class))).thenReturn(squeezeConfigPage);
+
+        ResponseEntity<?> response = squeezeConfigController.searchSqueezePages("keyword", pageable);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertEquals("Search completed successfully", responseBody.get("message"));
+        assertEquals(HttpStatus.OK.value(), responseBody.get("status_code"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testToggleSqueezePageActive() {
+        SqueezeConfig squeezeConfig = new SqueezeConfig();
+        squeezeConfig.setId(UUID.randomUUID());
+        squeezeConfig.setActive(true);
+
+        when(squeezeConfigService.toggleSqueezePageActive(any(UUID.class))).thenReturn(squeezeConfig);
+
+        ResponseEntity<?> response = squeezeConfigController.toggleSqueezePageActive(squeezeConfig.getId());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertEquals("Squeeze page active status toggled successfully", responseBody.get("message"));
+        assertEquals(squeezeConfig.getId(), responseBody.get("id"));
+        assertEquals(squeezeConfig.isActive(), responseBody.get("active"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteSqueezePageSuccess() {
+        when(squeezeConfigService.deleteSqueezePage(anyString())).thenReturn(true);
+
+        ResponseEntity<?> response = squeezeConfigController.deleteSqueezePage("some-id");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertEquals("Squeeze page deleted successfully", responseBody.get("message"));
+        assertEquals(200, responseBody.get("statusCode"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteSqueezePageNotFound() {
+        when(squeezeConfigService.deleteSqueezePage(anyString())).thenReturn(false);
+
+        ResponseEntity<?> response = squeezeConfigController.deleteSqueezePage("some-id");
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertEquals("Squeeze page not found", responseBody.get("message"));
+        assertEquals(404, responseBody.get("statusCode"));
+    }
+}

--- a/src/test/java/hng_java_boilerplate/squeeze/controller/SqueezeRequestControllerTest.java
+++ b/src/test/java/hng_java_boilerplate/squeeze/controller/SqueezeRequestControllerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -89,6 +90,45 @@ public class SqueezeRequestControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("Email address already exists"))
                 .andExpect(jsonPath("$.status_code").value(409));
+    }
+
+    @Test
+    public void testGetAllSqueezeRequests() throws Exception {
+        SqueezeRequest request1 = SqueezeRequest.builder()
+                .email("email1@example.com")
+                .first_name("FirstName1")
+                .last_name("LastName1")
+                .phone("1234567890")
+                .location("Location1")
+                .job_title("JobTitle1")
+                .company("Company1")
+                .interests(new ArrayList<>(List.of("Interest1", "Interest2")))
+                .referral_source("ReferralSource1")
+                .build();
+
+        SqueezeRequest request2 = SqueezeRequest.builder()
+                .email("email2@example.com")
+                .first_name("FirstName2")
+                .last_name("LastName2")
+                .phone("0987654321")
+                .location("Location2")
+                .job_title("JobTitle2")
+                .company("Company2")
+                .interests(new ArrayList<>(List.of("Interest3", "Interest4")))
+                .referral_source("ReferralSource2")
+                .build();
+
+        List<SqueezeRequest> requests = List.of(request1, request2);
+
+        when(service.getAllSqueezeRequests()).thenReturn(requests);
+
+        mockMvc.perform(get("/api/v1/squeeze")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].email").value("email1@example.com"))
+                .andExpect(jsonPath("$[0].first_name").value("FirstName1"))
+                .andExpect(jsonPath("$[1].email").value("email2@example.com"))
+                .andExpect(jsonPath("$[1].first_name").value("FirstName2"));
     }
 
 }


### PR DESCRIPTION
## How should this be manually tested?
**Try accessing the endpoint**
- Access route without being authenticated.
- Send a POST request to `/api/v1/squeeze/config` to retrive waitlist users (admin only).

### Request
```json
{
  "pageTitle": "Test Squeeze Page",
  "urlSlug": "test-squeeze-page",
  "headlineText": "Join Our Exciting Squeeze!",
  "subheadlineText": "Be the first to know about our launch",
  "bodyText": "We're working on something amazing. Sign up now to get early access and exclusive offers!"
}
```

### Response
```json
    {
    "status_code": 201,
    "id": "623228b5-6757-4c33-a683-84877768f70b",
    "message": "Squeeze config page created successfully"
}
```

## Checklist of what I did
- [x] Created an endpoint (POST `/api/v1/squeeze/config`) .
- [x] Implemented authentication and returned appropriate status codes.
- [x] Wrote unit tests.
- [x] Wrote integration tests for confirmation of requests.
