### PR TITLE
fix: notification settings api

### DIFF
--- a/src/main/java/hng_java_boilerplate/notification/controllers/NotificationSettingsController.java
+++ b/src/main/java/hng_java_boilerplate/notification/controllers/NotificationSettingsController.java
@@ -1,5 +1,8 @@
 package hng_java_boilerplate.notification.controllers;
 
+import hng_java_boilerplate.notification.dto.request.NotificationSettingsRequestDTO;
+import hng_java_boilerplate.notification.dto.response.ApiResponseDTO;
+import hng_java_boilerplate.notification.dto.response.NotificationSettingsResponseDTO;
 import hng_java_boilerplate.notification.models.NotificationSettings;
 import hng_java_boilerplate.notification.services.NotificationSettingsService;
 import lombok.RequiredArgsConstructor;
@@ -18,34 +21,24 @@ public class NotificationSettingsController {
     private final NotificationSettingsService service;
 
     @GetMapping
-    public ResponseEntity<?> getSettings() {
-        NotificationSettings settings = service.getSettings();
-        if (settings == null) {
-            return ResponseEntity.status(404).body("Settings not found");
-        }
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", "success");
-        response.put("message", "Notification preferences retrieved successfully");
-        response.put("status_code", 200);
-        response.put("data", settings);
-
+    public ResponseEntity<ApiResponseDTO<NotificationSettingsResponseDTO>> getSettings() {
+        NotificationSettingsResponseDTO settings = service.getSettings();
+        ApiResponseDTO<NotificationSettingsResponseDTO> response = new ApiResponseDTO<>();
+        response.setStatus("success");
+        response.setMessage("Notification preferences retrieved successfully");
+        response.setStatusCode(200);
+        response.setData(settings);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping
-    public ResponseEntity<?> updateSettings(@RequestBody NotificationSettings settings) {
-        NotificationSettings updatedSettings = service.updateSettings(settings);
-        if (updatedSettings == null) {
-            return ResponseEntity.status(404).body("Settings not found");
-        }
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", "success");
-        response.put("message", "Notification preferences updated successfully");
-        response.put("status_code", 200);
-        response.put("data", updatedSettings);
-
+    public ResponseEntity<ApiResponseDTO<NotificationSettingsResponseDTO>> updateSettings(@RequestBody NotificationSettingsRequestDTO settingsDTO) {
+        NotificationSettingsResponseDTO updatedSettings = service.updateSettings(settingsDTO);
+        ApiResponseDTO<NotificationSettingsResponseDTO> response = new ApiResponseDTO<>();
+        response.setStatus("success");
+        response.setMessage("Notification preferences updated successfully");
+        response.setStatusCode(200);
+        response.setData(updatedSettings);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/hng_java_boilerplate/notification/dto/request/NotificationSettingsRequestDTO.java
+++ b/src/main/java/hng_java_boilerplate/notification/dto/request/NotificationSettingsRequestDTO.java
@@ -1,0 +1,31 @@
+package hng_java_boilerplate.notification.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class NotificationSettingsRequestDTO {
+    @JsonProperty("mobile_push_notifications")
+    private boolean mobilePushNotifications;
+
+    @JsonProperty("email_notification_activity_in_workspace")
+    private boolean emailNotificationActivityInWorkspace;
+
+    @JsonProperty("email_notification_always_send_email_notifications")
+    private boolean emailNotificationAlwaysSendEmailNotifications;
+
+    @JsonProperty("email_notification_email_digest")
+    private boolean emailNotificationEmailDigest;
+
+    @JsonProperty("email_notification_announcement_and_update_emails")
+    private boolean emailNotificationAnnouncementAndUpdateEmails;
+
+    @JsonProperty("slack_notifications_activity_on_your_workspace")
+    private boolean slackNotificationsActivityOnYourWorkspace;
+
+    @JsonProperty("slack_notifications_always_send_email_notifications")
+    private boolean slackNotificationsAlwaysSendEmailNotifications;
+
+    @JsonProperty("slack_notifications_announcement_and_update_emails")
+    private boolean slackNotificationsAnnouncementAndUpdateEmails;
+}

--- a/src/main/java/hng_java_boilerplate/notification/dto/response/ApiResponseDTO.java
+++ b/src/main/java/hng_java_boilerplate/notification/dto/response/ApiResponseDTO.java
@@ -1,0 +1,11 @@
+package hng_java_boilerplate.notification.dto.response;
+
+import lombok.Data;
+
+@Data
+public class ApiResponseDTO <T> {
+    private String status;
+    private String message;
+    private int statusCode;
+    private T data;
+}

--- a/src/main/java/hng_java_boilerplate/notification/dto/response/NotificationSettingsResponseDTO.java
+++ b/src/main/java/hng_java_boilerplate/notification/dto/response/NotificationSettingsResponseDTO.java
@@ -1,0 +1,31 @@
+package hng_java_boilerplate.notification.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class NotificationSettingsResponseDTO {
+    @JsonProperty("mobile_push_notifications")
+    private boolean mobilePushNotifications;
+
+    @JsonProperty("email_notification_activity_in_workspace")
+    private boolean emailNotificationActivityInWorkspace;
+
+    @JsonProperty("email_notification_always_send_email_notifications")
+    private boolean emailNotificationAlwaysSendEmailNotifications;
+
+    @JsonProperty("email_notification_email_digest")
+    private boolean emailNotificationEmailDigest;
+
+    @JsonProperty("email_notification_announcement_and_update_emails")
+    private boolean emailNotificationAnnouncementAndUpdateEmails;
+
+    @JsonProperty("slack_notifications_activity_on_your_workspace")
+    private boolean slackNotificationsActivityOnYourWorkspace;
+
+    @JsonProperty("slack_notifications_always_send_email_notifications")
+    private boolean slackNotificationsAlwaysSendEmailNotifications;
+
+    @JsonProperty("slack_notifications_announcement_and_update_emails")
+    private boolean slackNotificationsAnnouncementAndUpdateEmails;
+}

--- a/src/main/java/hng_java_boilerplate/notification/services/NotificationSettingsService.java
+++ b/src/main/java/hng_java_boilerplate/notification/services/NotificationSettingsService.java
@@ -1,5 +1,7 @@
 package hng_java_boilerplate.notification.services;
 
+import hng_java_boilerplate.notification.dto.request.NotificationSettingsRequestDTO;
+import hng_java_boilerplate.notification.dto.response.NotificationSettingsResponseDTO;
 import hng_java_boilerplate.notification.models.NotificationSettings;
 import hng_java_boilerplate.notification.repositories.NotificationSettingsRepository;
 import hng_java_boilerplate.user.service.UserService;
@@ -12,37 +14,55 @@ public class NotificationSettingsService {
     private final NotificationSettingsRepository repository;
     private final UserService userService;
 
-    // Fetch userId from the user service
-    public NotificationSettings getSettings() {
+    public NotificationSettingsResponseDTO getSettings() {
         String userId = userService.getLoggedInUser().getId();
         if (userId == null) {
-            // Handle unauthorized access, maybe throw an exception
             throw new IllegalStateException("User not logged in");
         }
-        return repository.findByUserId(userId);
+        NotificationSettings settings = repository.findByUserId(userId);
+        if (settings == null) {
+            throw new IllegalStateException("Notification settings not found for user: " + userId);
+        }
+        return mapToResponseDTO(settings);
     }
 
-    public NotificationSettings updateSettings(NotificationSettings settings) {
+    public NotificationSettingsResponseDTO updateSettings(NotificationSettingsRequestDTO settingsDTO) {
         String userId = userService.getLoggedInUser().getId();
         if (userId == null) {
-            // Handle unauthorized access, maybe throw an exception
             throw new IllegalStateException("User not logged in");
         }
         NotificationSettings existingSettings = repository.findByUserId(userId);
         if (existingSettings != null) {
-            // Update the settings
-            existingSettings.setMobilePushNotifications(settings.getMobilePushNotifications());
-            existingSettings.setEmailNotificationActivityInWorkspace(settings.getEmailNotificationActivityInWorkspace());
-            existingSettings.setEmailNotificationAlwaysSendEmailNotifications(settings.getEmailNotificationAlwaysSendEmailNotifications());
-            existingSettings.setEmailNotificationEmailDigest(settings.getEmailNotificationEmailDigest());
-            existingSettings.setEmailNotificationAnnouncementAndUpdateEmails(settings.getEmailNotificationAnnouncementAndUpdateEmails());
-            existingSettings.setSlackNotificationsActivityOnYourWorkspace(settings.getSlackNotificationsActivityOnYourWorkspace());
-            existingSettings.setSlackNotificationsAlwaysSendEmailNotifications(settings.getSlackNotificationsAlwaysSendEmailNotifications());
-            existingSettings.setSlackNotificationsAnnouncementAndUpdateEmails(settings.getSlackNotificationsAnnouncementAndUpdateEmails());
-            return repository.save(existingSettings);
+            updateSettingsFromDTO(existingSettings, settingsDTO);
+            NotificationSettings updatedSettings = repository.save(existingSettings);
+            return mapToResponseDTO(updatedSettings);
         } else {
-            // Handle case where settings do not exist, maybe throw an exception or create new settings
             throw new IllegalStateException("Notification settings not found for user: " + userId);
         }
     }
+
+    private NotificationSettingsResponseDTO mapToResponseDTO(NotificationSettings settings) {
+        NotificationSettingsResponseDTO dto = new NotificationSettingsResponseDTO();
+        dto.setMobilePushNotifications(settings.getMobilePushNotifications());
+        dto.setEmailNotificationActivityInWorkspace(settings.getEmailNotificationActivityInWorkspace());
+        dto.setEmailNotificationAlwaysSendEmailNotifications(settings.getEmailNotificationAlwaysSendEmailNotifications());
+        dto.setEmailNotificationEmailDigest(settings.getEmailNotificationEmailDigest());
+        dto.setEmailNotificationAnnouncementAndUpdateEmails(settings.getEmailNotificationAnnouncementAndUpdateEmails());
+        dto.setSlackNotificationsActivityOnYourWorkspace(settings.getSlackNotificationsActivityOnYourWorkspace());
+        dto.setSlackNotificationsAlwaysSendEmailNotifications(settings.getSlackNotificationsAlwaysSendEmailNotifications());
+        dto.setSlackNotificationsAnnouncementAndUpdateEmails(settings.getSlackNotificationsAnnouncementAndUpdateEmails());
+        return dto;
+    }
+
+    private void updateSettingsFromDTO(NotificationSettings existingSettings, NotificationSettingsRequestDTO settingsDTO) {
+        existingSettings.setMobilePushNotifications(settingsDTO.isMobilePushNotifications());
+        existingSettings.setEmailNotificationActivityInWorkspace(settingsDTO.isEmailNotificationActivityInWorkspace());
+        existingSettings.setEmailNotificationAlwaysSendEmailNotifications(settingsDTO.isEmailNotificationAlwaysSendEmailNotifications());
+        existingSettings.setEmailNotificationEmailDigest(settingsDTO.isEmailNotificationEmailDigest());
+        existingSettings.setEmailNotificationAnnouncementAndUpdateEmails(settingsDTO.isEmailNotificationAnnouncementAndUpdateEmails());
+        existingSettings.setSlackNotificationsActivityOnYourWorkspace(settingsDTO.isSlackNotificationsActivityOnYourWorkspace());
+        existingSettings.setSlackNotificationsAlwaysSendEmailNotifications(settingsDTO.isSlackNotificationsAlwaysSendEmailNotifications());
+        existingSettings.setSlackNotificationsAnnouncementAndUpdateEmails(settingsDTO.isSlackNotificationsAnnouncementAndUpdateEmails());
+    }
+
 }

--- a/src/test/java/hng_java_boilerplate/notification/NotificationSettingsControllerTest.java
+++ b/src/test/java/hng_java_boilerplate/notification/NotificationSettingsControllerTest.java
@@ -1,33 +1,36 @@
 package hng_java_boilerplate.notification;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hng_java_boilerplate.config.WebSecurityConfig;
 import hng_java_boilerplate.notification.controllers.NotificationSettingsController;
-import hng_java_boilerplate.notification.models.NotificationSettings;
+import hng_java_boilerplate.notification.dto.request.NotificationSettingsRequestDTO;
+import hng_java_boilerplate.notification.dto.response.NotificationSettingsResponseDTO;
 import hng_java_boilerplate.notification.services.NotificationSettingsService;
 import hng_java_boilerplate.product.errorhandler.ProductErrorHandler;
 import hng_java_boilerplate.util.JwtUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Import(JwtUtils.class)
 @ExtendWith(SpringExtension.class)
+@Import({JwtUtils.class, WebSecurityConfig.class})
 @WebMvcTest(NotificationSettingsController.class)
 public class NotificationSettingsControllerTest {
 
@@ -35,66 +38,85 @@ public class NotificationSettingsControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private NotificationSettingsService service;
+    private NotificationSettingsService notificationSettingsService;
+
     @MockBean
     private ProductErrorHandler productErrorHandler;
 
     @BeforeEach
-    void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(new NotificationSettingsController(service)).build();
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
     }
 
+    @WithMockUser(username = "testuser", roles = {"USER"})
     @Test
-    void testGetSettings() throws Exception {
-        NotificationSettings settings = new NotificationSettings();
-        // Configure your NotificationSettings object here
+    public void testGetSettings() throws Exception {
+        NotificationSettingsResponseDTO settings = new NotificationSettingsResponseDTO();
+        settings.setMobilePushNotifications(true);
+        settings.setEmailNotificationActivityInWorkspace(true);
+        settings.setEmailNotificationAlwaysSendEmailNotifications(true);
+        settings.setEmailNotificationEmailDigest(true);
+        settings.setEmailNotificationAnnouncementAndUpdateEmails(true);
+        settings.setSlackNotificationsActivityOnYourWorkspace(true);
+        settings.setSlackNotificationsAlwaysSendEmailNotifications(true);
+        settings.setSlackNotificationsAnnouncementAndUpdateEmails(true);
 
-        when(service.getSettings()).thenReturn(settings);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", "success");
-        response.put("message", "Notification preferences retrieved successfully");
-        response.put("status_code", 200);
-        response.put("data", settings);
+        when(notificationSettingsService.getSettings()).thenReturn(settings);
 
         mockMvc.perform(get("/api/v1/notification-settings"))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"status\":\"success\",\"message\":\"Notification preferences retrieved successfully\",\"status_code\":200,\"data\":{}}"));
+                .andExpect(jsonPath("$.status", is("success")))
+                .andExpect(jsonPath("$.message", is("Notification preferences retrieved successfully")))
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.data.mobile_push_notifications", is(true)))
+                .andExpect(jsonPath("$.data.email_notification_activity_in_workspace", is(true)))
+                .andExpect(jsonPath("$.data.email_notification_always_send_email_notifications", is(true)))
+                .andExpect(jsonPath("$.data.email_notification_email_digest", is(true)))
+                .andExpect(jsonPath("$.data.email_notification_announcement_and_update_emails", is(true)))
+                .andExpect(jsonPath("$.data.slack_notifications_activity_on_your_workspace", is(true)))
+                .andExpect(jsonPath("$.data.slack_notifications_always_send_email_notifications", is(true)))
+                .andExpect(jsonPath("$.data.slack_notifications_announcement_and_update_emails", is(true)));
     }
 
+    @WithMockUser(username = "testuser", roles = {"USER"})
     @Test
-    void testUpdateSettings() throws Exception {
-        NotificationSettings settings = new NotificationSettings();
-        // Configure your NotificationSettings object with valid data
-        settings.setId(1L);
-        settings.setUserId("user123");
-        settings.setMobilePushNotifications(true);
-        settings.setEmailNotificationActivityInWorkspace(true);
-        settings.setEmailNotificationAlwaysSendEmailNotifications(false);
-        settings.setEmailNotificationEmailDigest(true);
-        settings.setEmailNotificationAnnouncementAndUpdateEmails(false);
-        settings.setSlackNotificationsActivityOnYourWorkspace(true);
-        settings.setSlackNotificationsAlwaysSendEmailNotifications(false);
-        settings.setSlackNotificationsAnnouncementAndUpdateEmails(true);
+    public void testUpdateSettings() throws Exception {
+        NotificationSettingsRequestDTO requestDTO = new NotificationSettingsRequestDTO();
+        requestDTO.setMobilePushNotifications(false);
+        requestDTO.setEmailNotificationActivityInWorkspace(false);
+        requestDTO.setEmailNotificationAlwaysSendEmailNotifications(false);
+        requestDTO.setEmailNotificationEmailDigest(false);
+        requestDTO.setEmailNotificationAnnouncementAndUpdateEmails(false);
+        requestDTO.setSlackNotificationsActivityOnYourWorkspace(false);
+        requestDTO.setSlackNotificationsAlwaysSendEmailNotifications(false);
+        requestDTO.setSlackNotificationsAnnouncementAndUpdateEmails(false);
 
-        when(service.updateSettings(Mockito.any(NotificationSettings.class))).thenReturn(settings);
+        NotificationSettingsResponseDTO responseDTO = new NotificationSettingsResponseDTO();
+        responseDTO.setMobilePushNotifications(false);
+        responseDTO.setEmailNotificationActivityInWorkspace(false);
+        responseDTO.setEmailNotificationAlwaysSendEmailNotifications(false);
+        responseDTO.setEmailNotificationEmailDigest(false);
+        responseDTO.setEmailNotificationAnnouncementAndUpdateEmails(false);
+        responseDTO.setSlackNotificationsActivityOnYourWorkspace(false);
+        responseDTO.setSlackNotificationsAlwaysSendEmailNotifications(false);
+        responseDTO.setSlackNotificationsAnnouncementAndUpdateEmails(false);
 
-        String jsonContent = "{ " +
-                "\"mobilePushNotifications\": true, " +
-                "\"emailNotificationActivityInWorkspace\": true, " +
-                "\"emailNotificationAlwaysSendEmailNotifications\": false, " +
-                "\"emailNotificationEmailDigest\": true, " +
-                "\"emailNotificationAnnouncementAndUpdateEmails\": false, " +
-                "\"slackNotificationsActivityOnYourWorkspace\": true, " +
-                "\"slackNotificationsAlwaysSendEmailNotifications\": false, " +
-                "\"slackNotificationsAnnouncementAndUpdateEmails\": true " +
-                "}";
+        when(notificationSettingsService.updateSettings(any(NotificationSettingsRequestDTO.class))).thenReturn(responseDTO);
 
         mockMvc.perform(patch("/api/v1/notification-settings")
-                        .contentType("application/json")
-                        .content(jsonContent))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"status\":\"success\",\"message\":\"Notification preferences updated successfully\",\"status_code\":200,\"data\":{}}"));
+                .andExpect(jsonPath("$.status", is("success")))
+                .andExpect(jsonPath("$.message", is("Notification preferences updated successfully")))
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.data.mobile_push_notifications", is(false)))
+                .andExpect(jsonPath("$.data.email_notification_activity_in_workspace", is(false)))
+                .andExpect(jsonPath("$.data.email_notification_always_send_email_notifications", is(false)))
+                .andExpect(jsonPath("$.data.email_notification_email_digest", is(false)))
+                .andExpect(jsonPath("$.data.email_notification_announcement_and_update_emails", is(false)))
+                .andExpect(jsonPath("$.data.slack_notifications_activity_on_your_workspace", is(false)))
+                .andExpect(jsonPath("$.data.slack_notifications_always_send_email_notifications", is(false)))
+                .andExpect(jsonPath("$.data.slack_notifications_announcement_and_update_emails", is(false)));
     }
-
 }


### PR DESCRIPTION
### **Summary**
This pull request addresses the standardization of field naming conventions in the NotificationSettingsRequestDTO and NotificationSettingsResponseDTO. The field names have been updated to use snake_case formatting to ensure consistency and clarity in the API responses.

**Changes**
**Updated DTO Field Names:**

Changed field names in NotificationSettingsRequestDTO and NotificationSettingsResponseDTO to use snake_case.
The new field names are as follows:
mobilePushNotifications -> mobile_push_notifications
emailNotificationActivityInWorkspace -> email_notification_activity_in_workspace
emailNotificationAlwaysSendEmailNotifications -> email_notification_always_send_email_notifications
emailNotificationEmailDigest -> email_notification_email_digest
emailNotificationAnnouncementAndUpdateEmails -> email_notification_announcement_and_update_emails
slackNotificationsActivityOnYourWorkspace -> slack_notifications_activity_on_your_workspace
slackNotificationsAlwaysSendEmailNotifications -> slack_notifications_always_send_email_notifications
slackNotificationsAnnouncementAndUpdateEmails -> slack_notifications_announcement_and_update_emails

**Controller and Service Layer Adjustments:**

Updated the NotificationSettingsController and NotificationSettingsService to use the new field names in their logic.
Test Methods Updated:

Updated test methods in NotificationSettingsControllerTest to match the new field naming conventions.
