### PR TITLE
[Fix]: : Change `job_id` from UUID to String

### DIFF
--- a/src/main/java/hng_java_boilerplate/video/dto/VideoPathDTO.java
+++ b/src/main/java/hng_java_boilerplate/video/dto/VideoPathDTO.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Data
 public class VideoPathDTO {
 
-    private UUID jobId;
+    private String jobId;
     private Map<String, byte[]> video;
 
     public void addVideo(String key, byte[] value){

--- a/src/main/java/hng_java_boilerplate/video/dto/VideoStatusDTO.java
+++ b/src/main/java/hng_java_boilerplate/video/dto/VideoStatusDTO.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Data
 public class VideoStatusDTO {
 
-    private UUID jobId;
+    private String jobId;
     private String status;
     private String message;
     private String outputVideoUrl;

--- a/src/main/java/hng_java_boilerplate/video/entity/VideoSuite.java
+++ b/src/main/java/hng_java_boilerplate/video/entity/VideoSuite.java
@@ -17,9 +17,8 @@ import java.util.UUID;
 @Data
 public class VideoSuite {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "job_id", updatable = false, nullable = false)
-    private UUID jobId;
+    private String jobId;
 
     @Column(name = "status", nullable = false)
     private String status;

--- a/src/main/java/hng_java_boilerplate/video/repository/VideoRepository.java
+++ b/src/main/java/hng_java_boilerplate/video/repository/VideoRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface VideoRepository extends JpaRepository<VideoSuite, UUID> {
+public interface VideoRepository extends JpaRepository<VideoSuite,String> {
 
 }

--- a/src/main/java/hng_java_boilerplate/video/service/VideoServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/video/service/VideoServiceImpl.java
@@ -36,7 +36,7 @@ public class VideoServiceImpl implements VideoService{
         VideoPathDTO videoPathDTO = new VideoPathDTO();
         VideoStatusDTO videoStatusDTO = new VideoStatusDTO();
         VideoSuite videoSuite;
-        UUID jobId = VideoUtils.generateUuid();
+        String jobId = VideoUtils.generateUuid();
 
         videoPathDTO.setJobId(jobId);
         int count = 1;

--- a/src/main/java/hng_java_boilerplate/video/service/VideoServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/video/service/VideoServiceImpl.java
@@ -60,7 +60,7 @@ public class VideoServiceImpl implements VideoService{
     @Override
     public VideoResponseDTO<VideoStatusDTO> getJob(String id) {
 
-        VideoSuite job = videoRepository.findById(UUID.fromString(id))
+        VideoSuite job = videoRepository.findById(id)
                 .orElseThrow(() -> new JobNotFound("Job doesn't exist"));
 
         return VideoUtils.response("Found", HttpStatus.OK.value(), true,

--- a/src/main/java/hng_java_boilerplate/video/utils/VideoUtils.java
+++ b/src/main/java/hng_java_boilerplate/video/utils/VideoUtils.java
@@ -42,11 +42,11 @@ public class VideoUtils {
         }
     }
 
-    public static UUID generateUuid(){
-        return UUID.randomUUID();
+    public static String generateUuid(){
+        return UUID.randomUUID().toString();
     }
 
-    public static VideoSuite videoSuite(UUID jobId, String status,
+    public static VideoSuite videoSuite(String jobId, String status,
                                         String outputVideoUrl, String jobType, String message){
         VideoSuite videoSuite = new VideoSuite();
 

--- a/src/main/resources/db/migration/V25__Video_table.sql
+++ b/src/main/resources/db/migration/V25__Video_table.sql
@@ -1,9 +1,6 @@
--- Enable the uuid-ossp extension
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
 -- Create the video_suite table
 CREATE TABLE video_suite (
-    job_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    job_id VARCHAR(36) PRIMARY KEY,
     status VARCHAR(10) NOT NULL,
     job_type VARCHAR(50) NOT NULL,
     progress INTEGER,

--- a/src/test/java/hng_java_boilerplate/video/GetJobTest.java
+++ b/src/test/java/hng_java_boilerplate/video/GetJobTest.java
@@ -36,7 +36,7 @@ public class GetJobTest {
     @Test
     public void testGetJobSuccess() {
 
-        UUID jobId = UUID.randomUUID();
+        String jobId = UUID.randomUUID().toString();
         VideoSuite mockJob = new VideoSuite();
         when(videoRepository.findById(jobId)).thenReturn(Optional.of(mockJob));
 
@@ -50,7 +50,7 @@ public class GetJobTest {
 
     @Test
     public void testGetJobNotFound() {
-        UUID jobId = UUID.randomUUID();
+        String jobId = UUID.randomUUID().toString();
         when(videoRepository.findById(jobId)).thenReturn(Optional.empty());
 
         assertThrows(JobNotFound.class, () -> videoService.getJob(jobId.toString()));


### PR DESCRIPTION


**Changes:**

1. **Database Schema:**
   - Updated the `video_suite` table schema to use `VARCHAR(36)` for the `job_id` instead of `UUID`.
 
2. **Entity Classes:**
   - Updated the `VideoSuite` entity class to reflect the change from `UUID` to `String`.

3. **Repository Interfaces:**
   - Updated repository interfaces to handle `String` type for `job_id`.

4. **Service Layer:**
   - Modified service layer methods and DTOs to use `String` for `job_id`.

5. **Controller Layer:**
   - Updated controller methods to handle `String` for `job_id`.

6. **Migration Files:**
   - Updated Flyway migration scripts to reflect the changes in the database schema.


**Testing:**

- **Unit Tests:** Updated unit tests to ensure compatibility with the new `String` type for `job_id`.


