### PR TITLE
feat: implement endpoint to delete testimonial

### DIFF
--- a/src/main/java/hng_java_boilerplate/testimonials/controller/TestimonialController.java
+++ b/src/main/java/hng_java_boilerplate/testimonials/controller/TestimonialController.java
@@ -13,12 +13,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RestController
@@ -106,4 +108,28 @@ public class TestimonialController {
 
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{testimonial_id}")
+    @Secured("ROLE_ADMIN")
+    public ResponseEntity<?> deleteTestimonial(@PathVariable("testimonial_id") String testimonialId) {
+        User loggedInUser = userService.getLoggedInUser();
+
+        if (loggedInUser == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "message", "User not authenticated", "error", "Unauthorized", "status_code", 401));
+        }
+
+        try {
+            testimonialService.deleteTestimonial(testimonialId);
+            return ResponseEntity.ok(Map.of(
+                    "success", true, "message", "Testimonial deleted successfully", "status_code", 200));
+        } catch (ResponseStatusException ex) {
+            return ResponseEntity.status(ex.getStatusCode()).body(Map.of(
+                    "message", Objects.requireNonNull(ex.getReason()), "error", ex.getStatusCode(), "status_code", ex.getStatusCode().value()));
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "message", "An error occurred while deleting the testimonial", "error", "Internal Server Error", "status_code", 500));
+        }
+    }
+
 }

--- a/src/main/java/hng_java_boilerplate/testimonials/service/TestimonialService.java
+++ b/src/main/java/hng_java_boilerplate/testimonials/service/TestimonialService.java
@@ -50,4 +50,11 @@ public class TestimonialService {
 
         return testimonialRepository.save(testimonial);
     }
+
+    public void deleteTestimonial(String testimonialId) {
+        Testimonial testimonial = testimonialRepository.findById(testimonialId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Testimonial not found"));
+
+        testimonialRepository.delete(testimonial);
+    }
 }

--- a/src/test/java/hng_java_boilerplate/testimonials/service/TestimonialServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/testimonials/service/TestimonialServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
@@ -18,7 +19,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class TestimonialServiceTest {
 
@@ -150,5 +151,30 @@ class TestimonialServiceTest {
         assertThrows(ResponseStatusException.class, () -> {
             testimonialService.updateTestimonial("testimonialId123", "userId123", "Updated content");
         });
+    }
+
+    @Test
+    void deleteTestimonial_shouldDeleteWhenFound() {
+        Testimonial testimonial = new Testimonial();
+        testimonial.setId("testimonialId123");
+
+        when(testimonialRepository.findById("testimonialId123")).thenReturn(Optional.of(testimonial));
+        doNothing().when(testimonialRepository).delete(testimonial);
+
+        testimonialService.deleteTestimonial("testimonialId123");
+
+        verify(testimonialRepository, times(1)).delete(testimonial);
+    }
+
+    @Test
+    void deleteTestimonial_shouldThrowExceptionWhenNotFound() {
+        when(testimonialRepository.findById("testimonialId123")).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            testimonialService.deleteTestimonial("testimonialId123");
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("Testimonial not found", exception.getReason());
     }
 }


### PR DESCRIPTION
## How should this be manually tested?
**Try accessing the endpoint**
- Access route authenticated as an admin.
- Send a DELETE request to `/api/v1/testimonials{testimonialId}` to delete a testimonial.

### Successful Response
```json
{
  "success": true,
  "message": "string",
  "status_code": 200
}
```

### Bad Request
```json
{
  "message": "string",
  "error": "string",
  "status_code": 400
}
```

### Unauthorized
```json
{
  "message": "string",
  "error": "string",
  "status_code": 401
}
```

## Checklist of what I did
- [x] Created an endpoint (DELETE `/api/v1/testimonials{testimonialId}`) .
- [x] Validated user input on the server side.
- [x] Securely stored user information in the database.
- [x] Implemented error handling and returned appropriate status codes.
- [x] Wrote unit tests for contact form submission and data validation.
- [x] Wrote integration tests for confirmation of requests.

## Reference Issue
[[FEAT]: API endpoint to delete a testimonial](https://github.com/hngprojects/hng_boilerplate_java_web/issues/300)