### PR TITLE
feat: implement endpoint to delete a job

### DIFF
--- a/src/main/java/hng_java_boilerplate/jobs/controller/JobListingController.java
+++ b/src/main/java/hng_java_boilerplate/jobs/controller/JobListingController.java
@@ -47,4 +47,11 @@ public class JobListingController {
         ApiResponse<JobListing> response = new ApiResponse<>("Job listing updated successfully", 200, updatedJob);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<String>> deleteJobListing(@PathVariable Long id) {
+        jobListingService.deleteJobListing(id);
+        ApiResponse<String> response = new ApiResponse<>("Job listing deleted successfully", 200, "Job deleted with id: " + id);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/hng_java_boilerplate/jobs/controller/JobListingController.java
+++ b/src/main/java/hng_java_boilerplate/jobs/controller/JobListingController.java
@@ -6,6 +6,7 @@ import hng_java_boilerplate.jobs.service.JobListingService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,6 +50,7 @@ public class JobListingController {
     }
 
     @DeleteMapping("/{id}")
+    @Secured("ROLE_ADMIN")
     public ResponseEntity<ApiResponse<String>> deleteJobListing(@PathVariable Long id) {
         jobListingService.deleteJobListing(id);
         ApiResponse<String> response = new ApiResponse<>("Job listing deleted successfully", 200, "Job deleted with id: " + id);

--- a/src/main/java/hng_java_boilerplate/jobs/service/JobListingService.java
+++ b/src/main/java/hng_java_boilerplate/jobs/service/JobListingService.java
@@ -9,4 +9,5 @@ public interface JobListingService {
     JobListing getJobListingById(Long id);
     List<JobListing> getAllJobListings();
     JobListing updateJobListing(Long id, JobListing updatedJobListing);
+    void deleteJobListing(Long id);
 }

--- a/src/main/java/hng_java_boilerplate/jobs/service/JobListingServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/jobs/service/JobListingServiceImpl.java
@@ -51,4 +51,11 @@ public class JobListingServiceImpl implements JobListingService {
 
         return jobListingRepository.save(existingJobListing);
     }
+
+    @Override
+    public void deleteJobListing(Long id) {
+        JobListing jobListing = getJobListingById(id);
+        jobListingRepository.delete(jobListing);
+    }
+
 }

--- a/src/test/java/hng_java_boilerplate/jobs/controller/JobListingControllerTest.java
+++ b/src/test/java/hng_java_boilerplate/jobs/controller/JobListingControllerTest.java
@@ -12,7 +12,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -59,6 +63,128 @@ class JobListingControllerTest {
                 .andExpect(jsonPath("$.data.jobType", is(jobListing.getJobType())))
                 .andExpect(jsonPath("$.data.companyName", is(jobListing.getCompanyName())))
                 .andExpect(jsonPath("$.data.createdAt", notNullValue()));
+    }
+
+    @Test
+    @WithMockUser
+    void getJobListingById_shouldReturnJobListing() throws Exception {
+        JobListing jobListing = new JobListing();
+        jobListing.setTitle("Software Engineer");
+        jobListing.setDescription("Develop amazing software");
+        jobListing.setLocation("Remote");
+        jobListing.setSalary("Competitive");
+        jobListing.setJobType("Full-time");
+        jobListing.setCompanyName("Tech Corp");
+        jobListing.setCreatedAt(LocalDateTime.now());
+        jobListing.setUpdatedAt(LocalDateTime.now());
+        jobListing = jobListingRepository.save(jobListing);
+
+        mockMvc.perform(get("/api/v1/jobs/{id}", jobListing.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Job listing retrieved successfully")))
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.data.id", is(jobListing.getId().intValue())))
+                .andExpect(jsonPath("$.data.title", is(jobListing.getTitle())))
+                .andExpect(jsonPath("$.data.description", is(jobListing.getDescription())))
+                .andExpect(jsonPath("$.data.location", is(jobListing.getLocation())))
+                .andExpect(jsonPath("$.data.salary", is(jobListing.getSalary())))
+                .andExpect(jsonPath("$.data.jobType", is(jobListing.getJobType())))
+                .andExpect(jsonPath("$.data.companyName", is(jobListing.getCompanyName())))
+                .andExpect(jsonPath("$.data.createdAt", notNullValue()));
+    }
+
+    @Test
+    @WithMockUser
+    void getAllJobListings_shouldReturnListOfJobListings() throws Exception {
+        JobListing jobListing1 = new JobListing();
+        jobListing1.setTitle("Software Engineer");
+        jobListing1.setDescription("Develop amazing software");
+        jobListing1.setLocation("Remote");
+        jobListing1.setSalary("Competitive");
+        jobListing1.setJobType("Full-time");
+        jobListing1.setCompanyName("Tech Corp");
+        jobListing1.setCreatedAt(LocalDateTime.now());
+        jobListing1.setUpdatedAt(LocalDateTime.now());
+        jobListingRepository.save(jobListing1);
+
+        JobListing jobListing2 = new JobListing();
+        jobListing2.setTitle("Product Manager");
+        jobListing2.setDescription("Manage product development");
+        jobListing2.setLocation("San Francisco, CA");
+        jobListing2.setSalary("Competitive");
+        jobListing2.setJobType("Full-time");
+        jobListing2.setCompanyName("InnovateX");
+        jobListing2.setCreatedAt(LocalDateTime.now());
+        jobListing2.setUpdatedAt(LocalDateTime.now());
+        jobListingRepository.save(jobListing2);
+
+        mockMvc.perform(get("/api/v1/jobs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Job listings retrieved successfully")))
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].title", is(jobListing1.getTitle())))
+                .andExpect(jsonPath("$.data[1].title", is(jobListing2.getTitle())));
+    }
+
+    @Test
+    @WithMockUser
+    void updateJobListing_shouldReturnUpdatedJobListing() throws Exception {
+        JobListing jobListing = new JobListing();
+        jobListing.setTitle("Software Engineer");
+        jobListing.setDescription("Develop amazing software");
+        jobListing.setLocation("Remote");
+        jobListing.setSalary("Competitive");
+        jobListing.setJobType("Full-time");
+        jobListing.setCompanyName("Tech Corp");
+        jobListing.setCreatedAt(LocalDateTime.now());
+        jobListing.setUpdatedAt(LocalDateTime.now());
+        jobListing = jobListingRepository.save(jobListing);
+
+        JobListing updatedJobListing = new JobListing();
+        updatedJobListing.setTitle("Senior Software Engineer");
+        updatedJobListing.setDescription("Develop and lead software projects");
+        updatedJobListing.setLocation("Remote");
+        updatedJobListing.setSalary("Very Competitive");
+        updatedJobListing.setJobType("Full-time");
+        updatedJobListing.setCompanyName("Tech Corp");
+
+        mockMvc.perform(put("/api/v1/jobs/{id}", jobListing.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedJobListing)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Job listing updated successfully")))
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.data.title", is(updatedJobListing.getTitle())))
+                .andExpect(jsonPath("$.data.description", is(updatedJobListing.getDescription())))
+                .andExpect(jsonPath("$.data.location", is(updatedJobListing.getLocation())))
+                .andExpect(jsonPath("$.data.salary", is(updatedJobListing.getSalary())))
+                .andExpect(jsonPath("$.data.jobType", is(updatedJobListing.getJobType())))
+                .andExpect(jsonPath("$.data.companyName", is(updatedJobListing.getCompanyName())));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteJobListing_shouldReturnSuccessMessage() throws Exception {
+        JobListing jobListing = new JobListing();
+        jobListing.setTitle("Software Engineer");
+        jobListing.setDescription("Develop amazing software");
+        jobListing.setLocation("Remote");
+        jobListing.setSalary("Competitive");
+        jobListing.setJobType("Full-time");
+        jobListing.setCompanyName("Tech Corp");
+        jobListing.setCreatedAt(LocalDateTime.now());
+        jobListing.setUpdatedAt(LocalDateTime.now());
+        jobListing = jobListingRepository.save(jobListing);
+
+        mockMvc.perform(delete("/api/v1/jobs/{id}", jobListing.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Job listing deleted successfully")))
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.data", is("Job deleted with id: " + jobListing.getId())));
+
+        Optional<JobListing> deletedJobListing = jobListingRepository.findById(jobListing.getId());
+        assertFalse(deletedJobListing.isPresent());
     }
 
 }

--- a/src/test/java/hng_java_boilerplate/jobs/service/JobListingServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/jobs/service/JobListingServiceTest.java
@@ -1,5 +1,6 @@
 package hng_java_boilerplate.jobs.service;
 
+import hng_java_boilerplate.helpCenter.topic.exceptions.ResourceNotFoundException;
 import hng_java_boilerplate.jobs.entity.JobListing;
 import hng_java_boilerplate.jobs.repository.JobListingRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,5 +64,98 @@ class JobListingServiceTest {
         assertNotNull(result.getCreatedAt());
 
         verify(jobListingRepository, times(1)).save(any(JobListing.class));
+    }
+
+    @Test
+    void getJobListingById_shouldReturnJobListing_whenJobExists() {
+        Long jobId = 1L;
+        JobListing jobListing = new JobListing();
+        jobListing.setId(jobId);
+        jobListing.setTitle("Software Engineer");
+
+        when(jobListingRepository.findById(jobId)).thenReturn(java.util.Optional.of(jobListing));
+
+        JobListing result = jobListingService.getJobListingById(jobId);
+
+        assertNotNull(result);
+        assertEquals(jobId, result.getId());
+        verify(jobListingRepository, times(1)).findById(jobId);
+    }
+
+    @Test
+    void getJobListingById_shouldThrowException_whenJobDoesNotExist() {
+        Long jobId = 1L;
+
+        when(jobListingRepository.findById(jobId)).thenReturn(java.util.Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> jobListingService.getJobListingById(jobId));
+        verify(jobListingRepository, times(1)).findById(jobId);
+    }
+
+    @Test
+    void getAllJobListings_shouldReturnListOfJobListings() {
+        JobListing jobListing1 = new JobListing();
+        jobListing1.setTitle("Software Engineer");
+
+        JobListing jobListing2 = new JobListing();
+        jobListing2.setTitle("Data Scientist");
+
+        List<JobListing> jobListings = List.of(jobListing1, jobListing2);
+
+        when(jobListingRepository.findAll()).thenReturn(jobListings);
+
+        List<JobListing> result = jobListingService.getAllJobListings();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        verify(jobListingRepository, times(1)).findAll();
+    }
+
+    @Test
+    void updateJobListing_shouldUpdateAndReturnUpdatedJobListing() {
+        Long jobId = 1L;
+        JobListing existingJobListing = new JobListing();
+        existingJobListing.setId(jobId);
+        existingJobListing.setTitle("Software Engineer");
+
+        JobListing updatedJobListing = new JobListing();
+        updatedJobListing.setTitle("Senior Software Engineer");
+        updatedJobListing.setDescription("Develop and design software");
+
+        when(jobListingRepository.findById(jobId)).thenReturn(java.util.Optional.of(existingJobListing));
+        when(jobListingRepository.save(any(JobListing.class))).thenReturn(existingJobListing);
+
+        JobListing result = jobListingService.updateJobListing(jobId, updatedJobListing);
+
+        assertNotNull(result);
+        assertEquals(jobId, result.getId());
+        assertEquals("Senior Software Engineer", result.getTitle());
+        assertEquals("Develop and design software", result.getDescription());
+        verify(jobListingRepository, times(1)).findById(jobId);
+        verify(jobListingRepository, times(1)).save(existingJobListing);
+    }
+
+    @Test
+    void deleteJobListing_shouldDeleteJobListing_whenJobExists() {
+        Long jobId = 1L;
+        JobListing jobListing = new JobListing();
+        jobListing.setId(jobId);
+
+        when(jobListingRepository.findById(jobId)).thenReturn(java.util.Optional.of(jobListing));
+
+        jobListingService.deleteJobListing(jobId);
+
+        verify(jobListingRepository, times(1)).findById(jobId);
+        verify(jobListingRepository, times(1)).delete(jobListing);
+    }
+
+    @Test
+    void deleteJobListing_shouldThrowException_whenJobDoesNotExist() {
+        Long jobId = 1L;
+
+        when(jobListingRepository.findById(jobId)).thenReturn(java.util.Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> jobListingService.deleteJobListing(jobId));
+        verify(jobListingRepository, times(1)).findById(jobId);
     }
 }


### PR DESCRIPTION
## How should this be manually tested?
**Try accessing the endpoint while authenticated as admin**
- Send a DELETE request to `/api/v1/jobs/{jobId}` to create a job listing.


### Response
```json
{
  "message": "Job listing deleted successfully",
  "status_code": 200,
  "data": "job with id 1234 deleted"
}
```

## Checklist of what I did
- [x] Created an endpoint (DELETE `/api/v1/jobs/{jobId}`) .
- [x] Implemented authentication and returned appropriate status codes.
- [x] Wrote unit tests.
- [x] Wrote integration tests for confirmation of requests.
