### PR TITLE
fix: video format conversion job type enum

### DIFF
--- a/src/main/java/hng_java_boilerplate/video/controller/VideoController.java
+++ b/src/main/java/hng_java_boilerplate/video/controller/VideoController.java
@@ -41,7 +41,7 @@ public class VideoController {
         List<VideoOutput> videoFormatList = Arrays.stream(VideoOutput.values())
                 .toList();
         String format = VideoUtils.getMatchingFormat("video/"+outputFormat, videoFormatList).toString();
-        String jobType = JobType.CONVERT_VIDEO.toString();
+        String jobType = JobType.ENCODE_VIDEO.toString();
         return new ResponseEntity<>(videoService.startVideoProcess(video, format, jobType), HttpStatus.CREATED);
     }
 
@@ -52,7 +52,7 @@ public class VideoController {
         VideoUploadDTO videoUploadDTO = new VideoUploadDTO();
         videoUploadDTO.setVideos(files);
 
-       return new ResponseEntity<>(videoService.videoConcat(videoUploadDTO), HttpStatus.CREATED);
+        return new ResponseEntity<>(videoService.videoConcat(videoUploadDTO), HttpStatus.CREATED);
     }
 
     @GetMapping("/{jobId}/status")

--- a/src/main/java/hng_java_boilerplate/video/videoEnums/JobType.java
+++ b/src/main/java/hng_java_boilerplate/video/videoEnums/JobType.java
@@ -4,7 +4,7 @@ public enum JobType {
 
     MERGE_VIDEO("merge video"),
     EXTRACT_AUDIO("extract audio"),
-    CONVERT_VIDEO("convert video");
+    ENCODE_VIDEO("encode video");
     private final String status;
 
     JobType(String status) {

--- a/src/test/java/hng_java_boilerplate/videoconversion/serviceImpl/VideoConversionServiceImplTest.java
+++ b/src/test/java/hng_java_boilerplate/videoconversion/serviceImpl/VideoConversionServiceImplTest.java
@@ -48,7 +48,7 @@ public class VideoConversionServiceImplTest {
         when(videoPublisher.sendVideo(any(VideoPathDTO.class))).thenReturn(true);
         when(videoRepository.save(any(VideoSuite.class))).thenReturn(new VideoSuite());
 
-        VideoResponseDTO<VideoStatusDTO> response = videoService.startVideoProcess(videoFile, "video/mp4", JobType.CONVERT_VIDEO.toString());
+        VideoResponseDTO<VideoStatusDTO> response = videoService.startVideoProcess(videoFile, "video/mp4", JobType.ENCODE_VIDEO.toString());
 
         assertNotNull(response);
         assertEquals("Job created", response.getMessage());
@@ -67,7 +67,7 @@ public class VideoConversionServiceImplTest {
         when(videoPublisher.sendVideo(any(VideoPathDTO.class))).thenReturn(false);
 
         JobCreationError exception = assertThrows(JobCreationError.class, () -> {
-            videoService.startVideoProcess(videoFile, "video/mp4", JobType.CONVERT_VIDEO.toString());
+            videoService.startVideoProcess(videoFile, "video/mp4", JobType.ENCODE_VIDEO.toString());
         });
 
         assertEquals("Error creating job", exception.getMessage());


### PR DESCRIPTION
This PR updates the job type to match with the one in the Video Suite application, changes CONVERT_VIDEO to ENCODE_VIDEO