### PR TITLE
feat: implement forgot password feature

### DIFF
--- a/src/main/java/hng_java_boilerplate/user/controller/AuthController.java
+++ b/src/main/java/hng_java_boilerplate/user/controller/AuthController.java
@@ -1,15 +1,18 @@
 package hng_java_boilerplate.user.controller;
 
 import hng_java_boilerplate.exception.UnAuthorizedException;
+import hng_java_boilerplate.user.dto.request.ForgotPasswordRequest;
 import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.OAuthDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
+import hng_java_boilerplate.user.dto.response.CustomResponse;
 import hng_java_boilerplate.user.dto.response.OAuthBaseResponse;
 import hng_java_boilerplate.user.service.UserService;
 import hng_java_boilerplate.util.FacebookJwtUtils;
 import hng_java_boilerplate.util.GoogleJwtUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -53,5 +56,11 @@ public class AuthController {
         } catch (UnAuthorizedException e) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<CustomResponse> forgotPassword(@RequestBody @Valid ForgotPasswordRequest request,
+                                                         HttpServletRequest servletRequest) {
+        return ResponseEntity.ok(userService.forgotPassword(request, servletRequest));
     }
 }

--- a/src/main/java/hng_java_boilerplate/user/dto/request/ForgotPasswordRequest.java
+++ b/src/main/java/hng_java_boilerplate/user/dto/request/ForgotPasswordRequest.java
@@ -1,0 +1,10 @@
+package hng_java_boilerplate.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ForgotPasswordRequest {
+    @NotBlank(message = "email is required")
+    private String email;
+}

--- a/src/main/java/hng_java_boilerplate/user/dto/response/CustomResponse.java
+++ b/src/main/java/hng_java_boilerplate/user/dto/response/CustomResponse.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.user.dto.response;
+
+public record CustomResponse(String message, int status_code) {
+}

--- a/src/main/java/hng_java_boilerplate/user/entity/User.java
+++ b/src/main/java/hng_java_boilerplate/user/entity/User.java
@@ -47,6 +47,8 @@ public class User implements UserDetails {
     @JsonIgnore
     private String secretKey;
 
+    private String forgotPasswordToken;
+
     private Boolean TwoFactorEnabled = false;
 
     @ManyToMany

--- a/src/main/java/hng_java_boilerplate/user/service/UserService.java
+++ b/src/main/java/hng_java_boilerplate/user/service/UserService.java
@@ -1,9 +1,11 @@
 package hng_java_boilerplate.user.service;
 
+import hng_java_boilerplate.user.dto.request.ForgotPasswordRequest;
 import hng_java_boilerplate.user.dto.request.GetUserDto;
 import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
+import hng_java_boilerplate.user.dto.response.CustomResponse;
 import hng_java_boilerplate.user.entity.User;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
@@ -14,9 +16,9 @@ public interface UserService {
     GetUserDto getUserWithDetails(String userId);
     ResponseEntity<ApiResponse> registerUser(SignupDto signupDto);
     ResponseEntity<String> verifyOtp(String email, String token, HttpServletRequest request);
+    CustomResponse forgotPassword(ForgotPasswordRequest passReq, HttpServletRequest request);
     User getLoggedInUser();
     ResponseEntity<ApiResponse> loginUser(LoginDto loginDto);
     User save(User user);
-
     User findUser(String id);
 }

--- a/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
@@ -4,10 +4,12 @@ import hng_java_boilerplate.activitylog.service.ActivityLogService;
 import hng_java_boilerplate.exception.BadRequestException;
 import hng_java_boilerplate.exception.NotFoundException;
 import hng_java_boilerplate.exception.UnAuthorizedException;
+import hng_java_boilerplate.user.dto.request.ForgotPasswordRequest;
 import hng_java_boilerplate.user.dto.request.GetUserDto;
 import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
+import hng_java_boilerplate.user.dto.response.CustomResponse;
 import hng_java_boilerplate.user.dto.response.ResponseData;
 import hng_java_boilerplate.user.dto.response.UserResponse;
 import hng_java_boilerplate.user.entity.User;
@@ -158,6 +160,20 @@ public class UserServiceImpl implements UserDetailsService, UserService {
     @Override
     public User findUser(String id) {
         return userRepository.findById(id).orElseThrow(() -> new NotFoundException("User not found"));
+    }
+
+    @Override
+    public CustomResponse forgotPassword(ForgotPasswordRequest passReq, HttpServletRequest request) {
+        User user = userRepository.findByEmail(passReq.getEmail())
+                .orElseThrow(() -> new BadRequestException("Account with the specified email doesn't exist"));
+
+        String token = emailService.generateToken();
+        user.setForgotPasswordToken(token);
+        userRepository.save(user);
+
+        emailService.passwordResetTokenMail(user, request, token);
+
+        return new CustomResponse("forgot password reset token generated successfully", 200);
     }
 
     // GetUserResponse method that combines both branches

--- a/src/main/resources/db/migration/V40__add_token_field_to_user.sql
+++ b/src/main/resources/db/migration/V40__add_token_field_to_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN forgot_password_token VARCHAR(100);

--- a/src/test/java/hng_java_boilerplate/user/verify_oto_test/UserServiceImplTest.java
+++ b/src/test/java/hng_java_boilerplate/user/verify_oto_test/UserServiceImplTest.java
@@ -1,6 +1,8 @@
 package hng_java_boilerplate.user.verify_oto_test;
 
 import hng_java_boilerplate.exception.BadRequestException;
+import hng_java_boilerplate.user.dto.request.ForgotPasswordRequest;
+import hng_java_boilerplate.user.dto.response.CustomResponse;
 import hng_java_boilerplate.user.entity.User;
 import hng_java_boilerplate.user.entity.VerificationToken;
 import hng_java_boilerplate.user.repository.UserRepository;
@@ -127,5 +129,23 @@ public class UserServiceImplTest {
         });
 
         assertEquals("User not found with email: notfound@example.com", exception.getMessage());
+    }
+
+
+    @Test
+    public void testForgotPassword() {
+        String email = "test@user.com";
+        ForgotPasswordRequest passwordRequest = new ForgotPasswordRequest();
+        passwordRequest.setEmail(email);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(new User()));
+
+        CustomResponse response = userServiceImpl.forgotPassword(passwordRequest, request);
+
+        assertEquals(200, response.status_code());
+        assertEquals("forgot password reset token generated successfully", response.message());
+
+        verify(userRepository).findByEmail(email);
+        verify(userRepository).save(any(User.class));
     }
 }


### PR DESCRIPTION
## Description
The application currently does not have an endpoint to handle forgot password request. This pull request creates an endpoint that sends the user provided user a token that is used by the user to reset their password.

### Expected Request
- send a post request to "/api/v1/auth/forgot-password
```json
{
  "email": "john@doe.com"
}
```
### Successful Response
```json
{
  "message": "string",
  "status_code": 0
}
```
### Acceptance criteria
- user gets a token to reset password
- input is properly validated
- proper exception handling

[related Issue](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/855)