### PR TITLE
feat: reset password token

### DIFF
--- a/src/main/java/hng_java_boilerplate/user/controller/AuthController.java
+++ b/src/main/java/hng_java_boilerplate/user/controller/AuthController.java
@@ -1,10 +1,7 @@
 package hng_java_boilerplate.user.controller;
 
 import hng_java_boilerplate.exception.UnAuthorizedException;
-import hng_java_boilerplate.user.dto.request.EmailSenderDto;
-import hng_java_boilerplate.user.dto.request.LoginDto;
-import hng_java_boilerplate.user.dto.request.OAuthDto;
-import hng_java_boilerplate.user.dto.request.SignupDto;
+import hng_java_boilerplate.user.dto.request.*;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
 import hng_java_boilerplate.user.dto.response.OAuthBaseResponse;
 import hng_java_boilerplate.user.service.UserService;
@@ -61,5 +58,10 @@ public class AuthController {
     public ResponseEntity<String> forgotPassword(@RequestBody EmailSenderDto passwordDto, HttpServletRequest request){
         userService.forgotPassword(passwordDto, request);
         return new ResponseEntity<>("Forgot password email sent successfully", HttpStatus.OK);
+    }
+
+    @PostMapping("/reset-password/{token}")
+    public ResponseEntity<String> resetPassword(@PathVariable String token, @RequestBody ResetPasswordDto passwordDto) {
+        return userService.resetPassword(token, passwordDto);
     }
 }

--- a/src/main/java/hng_java_boilerplate/user/dto/request/ResetPasswordDto.java
+++ b/src/main/java/hng_java_boilerplate/user/dto/request/ResetPasswordDto.java
@@ -1,0 +1,12 @@
+package hng_java_boilerplate.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPasswordDto {
+    private String new_password;
+}

--- a/src/main/java/hng_java_boilerplate/user/service/UserService.java
+++ b/src/main/java/hng_java_boilerplate/user/service/UserService.java
@@ -1,9 +1,6 @@
 package hng_java_boilerplate.user.service;
 
-import hng_java_boilerplate.user.dto.request.EmailSenderDto;
-import hng_java_boilerplate.user.dto.request.GetUserDto;
-import hng_java_boilerplate.user.dto.request.LoginDto;
-import hng_java_boilerplate.user.dto.request.SignupDto;
+import hng_java_boilerplate.user.dto.request.*;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
 import hng_java_boilerplate.user.entity.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,4 +16,5 @@ public interface UserService {
     User findUser(String id);
 
     void forgotPassword(EmailSenderDto passwordDto, HttpServletRequest request);
+    ResponseEntity<String> resetPassword(String token, ResetPasswordDto passwordDto);
 }

--- a/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
@@ -12,6 +12,7 @@ import hng_java_boilerplate.plans.service.PlanService;
 import hng_java_boilerplate.user.dto.request.GetUserDto;
 import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
+import hng_java_boilerplate.user.dto.request.*;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
 import hng_java_boilerplate.user.dto.response.ResponseData;
 import hng_java_boilerplate.user.dto.response.UserResponse;
@@ -156,6 +157,40 @@ public class UserServiceImpl implements UserDetailsService, UserService {
             passwordResetTokenRepository.delete(passwordResetToken);
         }
         passwordResetTokenRepository.save(newlyCreatedPasswordResetToken);
+    }
+
+    @Override
+    public ResponseEntity<String> resetPassword(String token, ResetPasswordDto passwordDto) {
+        String result = validatePasswordResetToken(token);
+        if (!result.equalsIgnoreCase("valid")) {
+            throw new UnAuthorizedException("Invalid Token");
+        }
+        Optional<User> user = Optional.ofNullable(passwordResetTokenRepository.findByToken(token).getUser());
+        if (user.isPresent()) {
+            changePassword(user.get(), passwordDto.getNew_password());
+            return new ResponseEntity<>("Password Reset Successful", HttpStatus.OK);
+        } else {
+            throw new UnAuthorizedException("Invalid Token");
+        }
+    }
+
+    private String validatePasswordResetToken(String token) {
+        PasswordResetToken passwordResetToken = passwordResetTokenRepository.findByToken(token);
+        if (passwordResetToken == null) {
+            return "invalid";
+        }
+        Calendar cal = Calendar.getInstance();
+        if (passwordResetToken.getExpirationTime().getTime()
+                - cal.getTime().getTime() <= 0) {
+            passwordResetTokenRepository.delete(passwordResetToken);
+            return "expired";
+        }
+        return "valid";
+    }
+
+    private void changePassword(User user, String newPassword) {
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
     }
 
     public User findUserByEmail(String username) {


### PR DESCRIPTION
### Description
Create a backend endpoint that allows users to reset their password using a secure token received via email. The endpoint should validate the token, accept the new password, and update the user’s credentials in the database.

### Changes made
- Created POST request endpoint to reset the password with a new password
- Created resetPassword method in the user service implementation class for the business logic

### How to test
#### Endpoint
`/api/v1/auth/reset-password/{token}`

#### Request Body
```json
{
    "new_password":"Password321"
}
``` 
#### Response
"Password Reset Successful"

### Linked issue
The feature is linke to the [issue](https://github.com/hngprojects/hng_boilerplate_java_web/issues/626)