### PR TITLE
feat: get single user

### DIFF
--- a/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
+++ b/src/main/java/hng_java_boilerplate/config/WebSecurityConfig.java
@@ -115,7 +115,9 @@ public class WebSecurityConfig {
                                         "/api/v1/organisations/**",
                                         "/api/v1/payment/stripe/**",
                                         "/api/v1/accounts/**",
-                                        "api/v1/auth/2fa/**", "/api/v1/users/members").authenticated())
+                                        "api/v1/auth/2fa/**",
+                                        "/api/v1/users/members",
+                                        "/api/v1/users/me/{id}").authenticated())
                 .logout(logout -> logout
                         .deleteCookies("remove")
                         .invalidateHttpSession(true)

--- a/src/main/java/hng_java_boilerplate/user/controller/UserController.java
+++ b/src/main/java/hng_java_boilerplate/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package hng_java_boilerplate.user.controller;
 
+import hng_java_boilerplate.exception.NotFoundException;
 import hng_java_boilerplate.user.dto.response.MembersResponse;
 import hng_java_boilerplate.user.dto.response.Response;
 import hng_java_boilerplate.user.service.UserService;
@@ -32,4 +33,15 @@ public class UserController {
         Response<?> response = Response.builder().message("Users List Successfully Fetched").status_code("200").data(allUsers).build();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @GetMapping("/me/{id}")
+    public ResponseEntity<?> getUserById(@PathVariable String id, Authentication authentication) {
+        try {
+            Response<?> response = userService.getUserById(id, authentication);
+            return ResponseEntity.status(response.getStatus_code().equals("200") ? 200 : 401).body(response);
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(404).body(Response.builder().status_code("404").message(e.getMessage()).build());
+        }
+    }
+
 }

--- a/src/main/java/hng_java_boilerplate/user/controller/UserController.java
+++ b/src/main/java/hng_java_boilerplate/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package hng_java_boilerplate.user.controller;
 
+import hng_java_boilerplate.exception.BadRequestException;
 import hng_java_boilerplate.exception.NotFoundException;
 import hng_java_boilerplate.user.dto.response.MembersResponse;
 import hng_java_boilerplate.user.dto.response.Response;
@@ -34,14 +35,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+
     @GetMapping("/me/{id}")
-    public ResponseEntity<?> getUserById(@PathVariable String id, Authentication authentication) {
-        try {
-            Response<?> response = userService.getUserById(id, authentication);
-            return ResponseEntity.status(response.getStatus_code().equals("200") ? 200 : 401).body(response);
-        } catch (NotFoundException e) {
-            return ResponseEntity.status(404).body(Response.builder().status_code("404").message(e.getMessage()).build());
-        }
+    public Response<?> getUserById(@PathVariable String id, Authentication authentication) {
+        return userService.getUserById(id, authentication);
     }
+
 
 }

--- a/src/main/java/hng_java_boilerplate/user/service/UserService.java
+++ b/src/main/java/hng_java_boilerplate/user/service/UserService.java
@@ -6,6 +6,7 @@ import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
 import hng_java_boilerplate.user.dto.response.ApiResponse;
 import hng_java_boilerplate.user.dto.response.MembersResponse;
+import hng_java_boilerplate.user.dto.response.Response;
 import hng_java_boilerplate.user.entity.User;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
@@ -26,5 +27,7 @@ public interface UserService {
     void forgotPassword(EmailSenderDto passwordDto, HttpServletRequest request);
 
     List<MembersResponse> getAllUsers(int page, Authentication authentication);
+
+    Response<?> getUserById(String userId, Authentication authentication);
 
 }

--- a/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
@@ -304,7 +304,7 @@ public class UserServiceImpl implements UserDetailsService, UserService {
         String email = authentication.getName();
 
         if (!userRepository.existsByEmail(email)) {
-            return Response.builder().status_code("401").message("Unauthorized").build();
+            throw new BadRequestException("Email does not exist");
         }
 
         Optional<User> userOptional = userRepository.findById(userId);

--- a/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/user/serviceImpl/UserServiceImpl.java
@@ -12,10 +12,7 @@ import hng_java_boilerplate.plans.service.PlanService;
 import hng_java_boilerplate.user.dto.request.GetUserDto;
 import hng_java_boilerplate.user.dto.request.LoginDto;
 import hng_java_boilerplate.user.dto.request.SignupDto;
-import hng_java_boilerplate.user.dto.response.ApiResponse;
-import hng_java_boilerplate.user.dto.response.MembersResponse;
-import hng_java_boilerplate.user.dto.response.ResponseData;
-import hng_java_boilerplate.user.dto.response.UserResponse;
+import hng_java_boilerplate.user.dto.response.*;
 import hng_java_boilerplate.user.entity.PasswordResetToken;
 import hng_java_boilerplate.user.entity.User;
 import hng_java_boilerplate.user.entity.VerificationToken;
@@ -301,4 +298,28 @@ public class UserServiceImpl implements UserDetailsService, UserService {
         }
         return users;
     }
+
+    @Override
+    public Response<?> getUserById(String userId, Authentication authentication) {
+        String email = authentication.getName();
+
+        if (!userRepository.existsByEmail(email)) {
+            return Response.builder().status_code("401").message("Unauthorized").build();
+        }
+
+        Optional<User> userOptional = userRepository.findById(userId);
+        if (userOptional.isPresent()) {
+            User foundUser = userOptional.get();
+            Map<String, String> data = new LinkedHashMap<>();
+            data.put("id", foundUser.getId());
+            data.put("fullname", foundUser.getName());
+            data.put("email", foundUser.getEmail());
+            data.put("role", foundUser.getUserRole().toString());
+            data.put("createdAt", foundUser.getCreatedAt() != null ? foundUser.getCreatedAt().toString() : "N/A");
+            return Response.builder().status_code("200").message("User data successfully fetched").data(data).build();
+        } else {
+            throw new NotFoundException("User not found with id: " + userId);
+        }
+    }
+
 }

--- a/src/test/java/hng_java_boilerplate/user/crud_operations_test/GetSingleUserTest.java
+++ b/src/test/java/hng_java_boilerplate/user/crud_operations_test/GetSingleUserTest.java
@@ -1,0 +1,54 @@
+package hng_java_boilerplate.user.crud_operations_test;
+
+import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.enums.Role;
+import hng_java_boilerplate.user.repository.UserRepository;
+import hng_java_boilerplate.user.serviceImpl.UserServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GetSingleUserTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private User user;
+    @BeforeEach
+    public void setUp() {
+        user = new User();
+        user.setId("id");
+        user.setUserRole(Role.ROLE_USER);
+        user.setName("Name");
+        user.setPassword("password123@");
+        user.setEmail("omoyeni76@gmail.com");
+        user.setCreatedAt(LocalDateTime.now());
+    }
+    @Test
+    public void getSingleUserTest() {
+        when(authentication.getName()).thenReturn("omoyeni76@gmail.com");
+
+        when(userRepository.existsByEmail("omoyeni76@gmail.com")).thenReturn(true);
+        when(userRepository.findById("id")).thenReturn(Optional.of(user));
+        var response = userService.getUserById("id", authentication);
+        assertNotNull(response);
+    }
+
+}


### PR DESCRIPTION
## How this should be manually

**Try accessing the endpoint**

- Access the route as an authenticated user.
- Send a GET request to `/api/v1/users/me/{id}` to retrieve the details of a single user by their ID.

#### Request
```
GET /api/v1/users/me/{id}
```


#### Response
```
{
    "status": "200",
    "message": "User data successfully fetched",
    "data": {
        "id": "123e4567-e89b-12d3-a456-426614174000",
        "fullName": "John Doe",
        "email": "john.doe@example.com",
        "createdAt": "2024-08-08T12:34:56"
    }
}

```

![Res1](https://github.com/user-attachments/assets/768fde27-a659-4d49-a1c6-218cdc2a482a)


![Res3](https://github.com/user-attachments/assets/315ccd3a-7870-4fa5-8121-54a670130439)



## Checklist of What I did

- [ ] Implemented the `GET /api/v1/users/me/{id}` endpoint to fetch user details by ID.
- [ ] Validated that the user exists and returned appropriate responses if not found.
- [ ] Implemented error handling and returned appropriate status codes.
- [ ] Ensured the response includes relevant user details such as ID, full name, email, and creation date.
- [ ] Wrote unit tests to validate the service logic.

## Reference Issue
Link to Issue: [https://github.com/hngprojects/hng_boilerplate_java_web/issues/416]()