### PR TITLE
fix: update categories

### DIFF
--- a/src/main/java/hng_java_boilerplate/categories/controller/CategoryController.java
+++ b/src/main/java/hng_java_boilerplate/categories/controller/CategoryController.java
@@ -1,7 +1,11 @@
 package hng_java_boilerplate.categories.controller;
 
+import hng_java_boilerplate.categories.dto.CategoryDto;
+import hng_java_boilerplate.categories.dto.CategoryRequest;
+import hng_java_boilerplate.categories.dto.CustomResponse;
 import hng_java_boilerplate.categories.entity.Category;
 import hng_java_boilerplate.categories.service.CategoryService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,35 +23,24 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @PostMapping
-    public ResponseEntity<?> createCategory(@RequestBody Category category) {
-        Category createdCategory = categoryService.createCategory(category);
-        return new ResponseEntity<>(createdCategory, HttpStatus.CREATED);
+    public ResponseEntity<CategoryDto> createCategory(@RequestBody @Valid CategoryRequest category) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(categoryService.createCategory(category));
     }
 
     @GetMapping
-    public ResponseEntity<List<Category>> getAllCategories() {
-        List<Category> categories = categoryService.getAllCategories();
-        return ResponseEntity.ok(categories);
+    public ResponseEntity<List<CategoryDto>> getAllCategories() {
+       return ResponseEntity.ok(categoryService.getAllCategories());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> getCategoryById(@PathVariable UUID id) {
-        Optional<Category> category = categoryService.getCategoryById(id);
-        if (category.isPresent()) {
-            return ResponseEntity.ok(category.get());
-        } else {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Category not found");
-        }
+    public ResponseEntity<CategoryDto> getCategoryById(@PathVariable UUID id) {
+        return ResponseEntity.ok(categoryService.getCategoryById(id));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> deleteCategory(@PathVariable UUID id) {
-        Optional<Category> category = categoryService.getCategoryById(id);
-        if (category.isPresent()) {
-            categoryService.deleteCategory(id);
-            return ResponseEntity.ok("Category deleted successfully");
-        } else {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Category not found");
-        }
+    public ResponseEntity<CustomResponse> deleteCategory(@PathVariable UUID id) {
+       return ResponseEntity.ok(categoryService.deleteCategory(id));
     }
 }

--- a/src/main/java/hng_java_boilerplate/categories/dto/CategoryDto.java
+++ b/src/main/java/hng_java_boilerplate/categories/dto/CategoryDto.java
@@ -1,0 +1,23 @@
+package hng_java_boilerplate.categories.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDto {
+    private UUID category_id;
+    private String name;
+    private String description;
+    private String slug;
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/hng_java_boilerplate/categories/dto/CategoryRequest.java
+++ b/src/main/java/hng_java_boilerplate/categories/dto/CategoryRequest.java
@@ -1,0 +1,16 @@
+package hng_java_boilerplate.categories.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CategoryRequest {
+    @NotBlank(message = "name is required")
+    private String name;
+    @NotBlank(message = "description is required")
+    private String description;
+    @NotBlank(message = "slug is required")
+    private String slug;
+}

--- a/src/main/java/hng_java_boilerplate/categories/dto/CustomResponse.java
+++ b/src/main/java/hng_java_boilerplate/categories/dto/CustomResponse.java
@@ -1,0 +1,4 @@
+package hng_java_boilerplate.categories.dto;
+
+public record CustomResponse(int status_code, String message) {
+}

--- a/src/main/java/hng_java_boilerplate/categories/service/CategoryService.java
+++ b/src/main/java/hng_java_boilerplate/categories/service/CategoryService.java
@@ -1,5 +1,8 @@
 package hng_java_boilerplate.categories.service;
 
+import hng_java_boilerplate.categories.dto.CategoryDto;
+import hng_java_boilerplate.categories.dto.CategoryRequest;
+import hng_java_boilerplate.categories.dto.CustomResponse;
 import hng_java_boilerplate.categories.entity.Category;
 
 import java.util.List;
@@ -7,9 +10,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface CategoryService {
-    Category createCategory(Category category);
-    List<Category> getAllCategories();
-    Optional<Category> getCategoryById(UUID id);
-    void deleteCategory(UUID id);
+    CategoryDto createCategory(CategoryRequest category);
+    List<CategoryDto> getAllCategories();
+    CategoryDto getCategoryById(UUID category_id);
+    CustomResponse deleteCategory(UUID category_id);
 }
 

--- a/src/main/java/hng_java_boilerplate/categories/service/CategoryServiceImpl.java
+++ b/src/main/java/hng_java_boilerplate/categories/service/CategoryServiceImpl.java
@@ -1,13 +1,16 @@
 package hng_java_boilerplate.categories.service;
 
+import hng_java_boilerplate.categories.dto.CategoryDto;
+import hng_java_boilerplate.categories.dto.CategoryRequest;
+import hng_java_boilerplate.categories.dto.CustomResponse;
 import hng_java_boilerplate.categories.entity.Category;
 import hng_java_boilerplate.categories.repository.CategoryRepository;
+import hng_java_boilerplate.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -17,25 +20,54 @@ public class CategoryServiceImpl implements CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Override
-    public Category createCategory(Category category) {
-        category.setCreatedAt(LocalDateTime.now());
-        category.setUpdatedAt(LocalDateTime.now());
-        return categoryRepository.save(category);
+    public CategoryDto createCategory(CategoryRequest request) {
+        Category newCategory = new Category();
+        newCategory.setName(request.getName());
+        newCategory.setDescription(request.getDescription());
+        newCategory.setSlug(request.getSlug());
+        newCategory.setCreatedAt(LocalDateTime.now());
+        newCategory.setUpdatedAt(LocalDateTime.now());
+
+        categoryRepository.saveAndFlush(newCategory);
+
+        return mapCategory(newCategory);
     }
 
     @Override
-    public List<Category> getAllCategories() {
-        return categoryRepository.findAll();
+    public List<CategoryDto> getAllCategories() {
+        List<Category> categories =  categoryRepository.findAll();
+
+        return  categories.stream()
+                .map(this::mapCategory)
+                .toList();
     }
 
     @Override
-    public Optional<Category> getCategoryById(UUID id) {
-        return categoryRepository.findById(id);
+    public CategoryDto getCategoryById(UUID id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("category not found with id"));
+
+        return mapCategory(category);
     }
 
     @Override
-    public void deleteCategory(UUID id) {
-        categoryRepository.deleteById(id);
+    public CustomResponse deleteCategory(UUID id) {
+        Category category = categoryRepository.findById(id)
+                        .orElseThrow(() -> new NotFoundException("category not found with id" + id));
+        categoryRepository.delete(category);
+
+        return new CustomResponse(200, "category deleted successfully");
+    }
+
+    private CategoryDto mapCategory(Category category) {
+        return CategoryDto.builder()
+                .category_id(category.getId())
+                .name(category.getName())
+                .description(category.getDescription())
+                .slug(category.getSlug())
+                .created_at(category.getCreatedAt())
+                .updated_at(category.getUpdatedAt())
+                .build();
     }
 }
 

--- a/src/test/java/hng_java_boilerplate/categories/controller/CategoryControllerTest.java
+++ b/src/test/java/hng_java_boilerplate/categories/controller/CategoryControllerTest.java
@@ -1,6 +1,8 @@
 package hng_java_boilerplate.categories.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import hng_java_boilerplate.categories.dto.CategoryDto;
+import hng_java_boilerplate.categories.dto.CategoryRequest;
 import hng_java_boilerplate.categories.entity.Category;
 import hng_java_boilerplate.categories.service.CategoryService;
 import org.junit.jupiter.api.Test;
@@ -37,15 +39,15 @@ public class CategoryControllerTest {
 
     @Test
     void testCreateCategory() throws Exception {
-        Category category = new Category();
-        category.setId(UUID.randomUUID());
+        CategoryDto category = new CategoryDto();
+        category.setCategory_id(UUID.randomUUID());
         category.setName("Test Category");
         category.setDescription("Test Description");
         category.setSlug("test-category");
-        category.setCreatedAt(LocalDateTime.now());
-        category.setUpdatedAt(LocalDateTime.now());
+        category.setCreated_at(LocalDateTime.now());
+        category.setUpdated_at(LocalDateTime.now());
 
-        when(categoryService.createCategory(any(Category.class))).thenReturn(category);
+        when(categoryService.createCategory(any(CategoryRequest.class))).thenReturn(category);
 
         mockMvc.perform(post("/api/v1/categories")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -57,13 +59,13 @@ public class CategoryControllerTest {
 
     @Test
     void testGetAllCategories() throws Exception {
-        Category category = new Category();
-        category.setId(UUID.randomUUID());
+        CategoryDto category = new CategoryDto();
+        category.setCategory_id(UUID.randomUUID());
         category.setName("Test Category");
         category.setDescription("Test Description");
         category.setSlug("test-category");
-        category.setCreatedAt(LocalDateTime.now());
-        category.setUpdatedAt(LocalDateTime.now());
+        category.setCreated_at(LocalDateTime.now());
+        category.setUpdated_at(LocalDateTime.now());
 
         when(categoryService.getAllCategories()).thenReturn(List.of(category));
 

--- a/src/test/java/hng_java_boilerplate/categories/service/CategoryServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/categories/service/CategoryServiceTest.java
@@ -1,5 +1,7 @@
 package hng_java_boilerplate.categories.service;
 
+import hng_java_boilerplate.categories.dto.CategoryDto;
+import hng_java_boilerplate.categories.dto.CategoryRequest;
 import hng_java_boilerplate.categories.entity.Category;
 import hng_java_boilerplate.categories.repository.CategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +10,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -36,13 +37,15 @@ class CategoryServiceTest {
         category.setName("Test Category");
         when(categoryRepository.save(any(Category.class))).thenReturn(category);
 
-        Category createdCategory = categoryService.createCategory(category);
+        CategoryRequest request = new CategoryRequest();
+        request.setName(category.getName());
+        CategoryDto createdCategory = categoryService.createCategory(request);
 
         assertNotNull(createdCategory);
         assertEquals("Test Category", createdCategory.getName());
-        assertNotNull(createdCategory.getCreatedAt());
-        assertNotNull(createdCategory.getUpdatedAt());
-        verify(categoryRepository, times(1)).save(category);
+        assertNotNull(createdCategory.getCreated_at());
+        assertNotNull(createdCategory.getUpdated_at());
+        verify(categoryRepository, times(1)).saveAndFlush(any(Category.class));
     }
 
     @Test
@@ -50,9 +53,8 @@ class CategoryServiceTest {
         List<Category> categories = Arrays.asList(new Category(), new Category());
         when(categoryRepository.findAll()).thenReturn(categories);
 
-        List<Category> result = categoryService.getAllCategories();
+        List<CategoryDto> result = categoryService.getAllCategories();
 
-        assertEquals(categories, result);
         verify(categoryRepository, times(1)).findAll();
     }
 
@@ -62,19 +64,22 @@ class CategoryServiceTest {
         Category category = new Category();
         when(categoryRepository.findById(id)).thenReturn(Optional.of(category));
 
-        Optional<Category> result = categoryService.getCategoryById(id);
+        CategoryDto result = categoryService.getCategoryById(id);
 
-        assertTrue(result.isPresent());
-        assertEquals(category, result.get());
+        assertEquals(category.getId(), result.getCategory_id());
+        assertEquals(category.getName(), result.getName());
         verify(categoryRepository, times(1)).findById(id);
     }
 
     @Test
     void deleteCategory() {
         UUID id = UUID.randomUUID();
+        Category category = new Category();
+
+        when(categoryRepository.findById(id)).thenReturn(Optional.of(category));
 
         categoryService.deleteCategory(id);
 
-        verify(categoryRepository, times(1)).deleteById(id);
+        verify(categoryRepository, times(1)).delete(category);
     }
 }


### PR DESCRIPTION
## Description
category endpoints are not using dtos and creation of category was requesting for the id of the category to create which should not be manually supplied. Also the tester were finding it difficult understanding the documentation due to lack of usage of dto.

## Changes made
- use dto for request and response
- remove the category id from being the request body when user wants to create a category
- make the request body conform to the request convention we are using
- update the tests based on these changes