### PR TITLE
feat: add GET /api/v1/organisations/{organisationId} endpoint

### DIFF
--- a/src/main/java/hng_java_boilerplate/organisation/controller/OrganisationController.java
+++ b/src/main/java/hng_java_boilerplate/organisation/controller/OrganisationController.java
@@ -2,6 +2,7 @@ package hng_java_boilerplate.organisation.controller;
 
 import hng_java_boilerplate.organisation.dto.CreateOrganisationRequestDto;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationResponseDto;
+import hng_java_boilerplate.organisation.entity.Organisation;
 import hng_java_boilerplate.organisation.service.OrganisationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -9,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +27,11 @@ public class OrganisationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 organisationService.create(orgRequest, activeUser)
         );
+    }
+
+    @GetMapping("/{organisationId}")
+    public ResponseEntity<?> getOrganisationById(@PathVariable String organisationId) {
+        Organisation organisation = organisationService.getOrganisationById(organisationId);
+        return ResponseEntity.ok(organisation);
     }
 }

--- a/src/main/java/hng_java_boilerplate/organisation/service/OrganisationService.java
+++ b/src/main/java/hng_java_boilerplate/organisation/service/OrganisationService.java
@@ -85,6 +85,5 @@ public class OrganisationService {
     public Organisation getOrganisationById(String organisationId) {
         return organisationRepository.findById(organisationId)
                 .orElseThrow(() -> new NotFoundException("Organization not found"));
-
     }
 }

--- a/src/main/java/hng_java_boilerplate/organisation/service/OrganisationService.java
+++ b/src/main/java/hng_java_boilerplate/organisation/service/OrganisationService.java
@@ -1,6 +1,7 @@
 package hng_java_boilerplate.organisation.service;
 
 import hng_java_boilerplate.activitylog.service.ActivityLogService;
+import hng_java_boilerplate.exception.NotFoundException;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationRequestDto;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationResponseDto;
 import hng_java_boilerplate.organisation.dto.DataDto;
@@ -79,5 +80,11 @@ public class OrganisationService {
                 )
                 .status_code(201)
                 .build();
+    }
+
+    public Organisation getOrganisationById(String organisationId) {
+        return organisationRepository.findById(organisationId)
+                .orElseThrow(() -> new NotFoundException("Organization not found"));
+
     }
 }

--- a/src/test/java/hng_java_boilerplate/organisation/service/OrganisationServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/organisation/service/OrganisationServiceTest.java
@@ -1,5 +1,6 @@
 package hng_java_boilerplate.organisation.service;
 
+import hng_java_boilerplate.exception.NotFoundException;
 import hng_java_boilerplate.activitylog.service.ActivityLogService;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationRequestDto;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationResponseDto;
@@ -20,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -51,6 +51,7 @@ class OrganisationServiceTest {
 
     private CreateOrganisationRequestDto orgRequest;
     private User user;
+    private Organisation organisation;
 
     @BeforeEach
     void setUp() {
@@ -66,6 +67,11 @@ class OrganisationServiceTest {
         );
         user = new User();
         user.setId("user-123");
+
+        organisation = new Organisation();
+        organisation.setId("org-123");
+        organisation.setName("Test Organisation");
+        organisation.setDescription("A test org");
     }
 
     @Test
@@ -130,4 +136,30 @@ class OrganisationServiceTest {
         assertEquals("Name must not be empty", errors.get(0).message());
     }
 
+    @Test
+    void getOrganisationById_shouldReturnOrganisation_whenOrganisationExists() {
+        String organisationId = "org-123";
+        when(organisationRepository.findById(organisationId)).thenReturn(Optional.of(organisation));
+
+        Organisation result = organisationService.getOrganisationById(organisationId);
+
+        assertNotNull(result);
+        assertEquals(organisationId, result.getId());
+        assertEquals("Test Organisation", result.getName());
+        verify(organisationRepository, times(1)).findById(organisationId);
+    }
+
+    @Test
+    void getOrganisationById_shouldThrowNotFoundException_whenOrganisationDoesNotExist() {
+        String organisationId = "nonexistent-id";
+        when(organisationRepository.findById(organisationId)).thenReturn(Optional.empty());
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> organisationService.getOrganisationById(organisationId)
+        );
+
+        assertEquals("Organization not found", exception.getMessage());
+        verify(organisationRepository, times(1)).findById(organisationId);
+    }
 }

--- a/src/test/java/hng_java_boilerplate/organisation/service/e2e.java
+++ b/src/test/java/hng_java_boilerplate/organisation/service/e2e.java
@@ -2,6 +2,8 @@ package hng_java_boilerplate.organisation.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hng_java_boilerplate.organisation.dto.CreateOrganisationRequestDto;
+import hng_java_boilerplate.organisation.entity.Organisation;
+import hng_java_boilerplate.organisation.repository.OrganisationRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -9,8 +11,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -19,25 +23,49 @@ public class e2e {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private OrganisationRepository organisationRepository;
+
     @Test
     public void create_shouldReturn403_whenUserIsNotAuthenticated() throws Exception {
         // Arrange
         CreateOrganisationRequestDto orgRequest = new CreateOrganisationRequestDto(
-                "New Org",
-                "Description",
-                "email@example.com",
-                "Industry",
-                "Type",
-                "Country",
-                "Address",
-                "State"
+                "New Org", "Description", "email@example.com", "Industry", "Type", "Country", "Address", "State"
         );
 
-        // Act & Assert
         mockMvc.perform(post("/organisations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(asJsonString(orgRequest)))
                 .andExpect(status().isForbidden()); // Check for 403 Forbidden
+    }
+
+    @Test
+    public void getOrganisationById_shouldReturnOrganisation_whenOrganisationExists() throws Exception {
+        // Arrange
+        Organisation organisation = new Organisation();
+        organisation.setName("Test Org");
+        organisation.setDescription("Description");
+        organisation.setEmail("testorg@example.com");
+        organisation = organisationRepository.save(organisation);
+
+        mockMvc.perform(get("/api/v1/organisations/{organisationId}", organisation.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(organisation.getId()))
+                .andExpect(jsonPath("$.name").value("Test Org"))
+                .andExpect(jsonPath("$.description").value("Description"))
+                .andExpect(jsonPath("$.email").value("testorg@example.com"));
+    }
+
+    @Test
+    public void getOrganisationById_shouldReturn404_whenOrganisationDoesNotExist() throws Exception {
+        // Arrange
+        String nonExistentOrganisationId = "nonexistent-id";
+
+        mockMvc.perform(get("/api/v1/organisations/{organisationId}", nonExistentOrganisationId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Organization not found"));
     }
 
     // Helper method to convert object to JSON string
@@ -49,5 +77,4 @@ public class e2e {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/src/test/java/hng_java_boilerplate/organisation/service/e2e.java
+++ b/src/test/java/hng_java_boilerplate/organisation/service/e2e.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -46,7 +48,8 @@ public class e2e {
         organisation.setName("Test Org");
         organisation.setDescription("Description");
         organisation.setEmail("testorg@example.com");
-        organisation = organisationRepository.save(organisation);
+
+        when(organisationRepository.findById(anyString())).thenReturn(java.util.Optional.of(organisation));
 
         mockMvc.perform(get("/api/v1/organisations/{organisationId}", organisation.getId())
                         .contentType(MediaType.APPLICATION_JSON))
@@ -61,6 +64,8 @@ public class e2e {
     public void getOrganisationById_shouldReturn404_whenOrganisationDoesNotExist() throws Exception {
         // Arrange
         String nonExistentOrganisationId = "nonexistent-id";
+
+        when(organisationRepository.findById(anyString())).thenReturn(java.util.Optional.empty());
 
         mockMvc.perform(get("/api/v1/organisations/{organisationId}", nonExistentOrganisationId)
                         .contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
Resolves #679

# Description

- What was changed: Added a new endpoint GET /api/v1/organisations/{organisationId} to retrieve an organisation by its ID.
- Why it was changed: The feature was implemented to allow users to retrieve organisation details by its unique ID.

## Changes Implemented

- Implemented the getOrganisationById method in the OrganisationService class to retrieve an organisation by its ID.
- Added a new GET /api/v1/organisations/{organisationId} endpoint in the OrganisationController class.
- Created integration tests for the GET endpoint in the e2e test class to validate functionality for both valid and invalid organisation IDs.
- Added unit tests in the OrganisationServiceTest class for the getOrganisationById method to ensure correct behavior for existing and non-existing organisation IDs.
- Updated the response handling in the service to throw a NotFoundException when the organisation is not found.


## Manual testing performed: Validated API with Postman to ensure correct response for both valid and invalid organisation IDs:
- Screenshot from Postman
   Valid Organization ID Response

![Screenshot (18)](https://github.com/user-attachments/assets/54caeb2f-0e38-4ce5-946b-70c3c498a474)

   Invalid Organization ID Response

![Screenshot (23)](https://github.com/user-attachments/assets/6f097711-98c3-47c8-a340-453cbdb91bf1)


## Screenshot from Swagger
POST request to create an Organisation

![Screenshot (17)](https://github.com/user-attachments/assets/d0ce451b-8ec5-4c3f-8aa9-09fdfdabc7b9)

GET Organisation by ID

![Screenshot (16)](https://github.com/user-attachments/assets/d73a9d2e-f880-40ec-802f-1925b7e8f300)
