### PR TITLE
Feat] User can update their respective comment #685 Open

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 	<developers>
 		<developer/>
 	</developers>
+	
 	<scm>
 		<connection/>
 		<developerConnection/>

--- a/src/main/java/hng_java_boilerplate/comment/controller/CommentController.java
+++ b/src/main/java/hng_java_boilerplate/comment/controller/CommentController.java
@@ -52,6 +52,18 @@ public class CommentController {
         }
 
     }
+    
+    @PutMapping("/edit/{commentId}")
+    @PreAuthorize("@CommentService.isUserAuthorizedToUpdateComment(#commentId, principal.username)")
+    public ResponseEntity<Comment> updateComment(@PathVariable String commentId, @RequestParam String userId,@RequestBody Map<String, String> requestBody) {
+        String newCommentText = requestBody.get("comment");
+        if (newCommentText == null || newCommentText.trim().isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Comment updatedComment = commentService.updateComment(commentId, userId, newCommentText);
+        return ResponseEntity.ok(updatedComment);
+    }
 
     @DeleteMapping("/delete/{commentId}")
     @PreAuthorize("@CommentService.isUserAuthorizedToDeleteComment(#commentId, principal.username)")

--- a/src/main/java/hng_java_boilerplate/comment/repository/CommentRepository.java
+++ b/src/main/java/hng_java_boilerplate/comment/repository/CommentRepository.java
@@ -5,6 +5,7 @@ import hng_java_boilerplate.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+
 import java.util.Optional;
 
 

--- a/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
+++ b/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
@@ -1,20 +1,24 @@
 package hng_java_boilerplate.comment.service;
 
-import hng_java_boilerplate.comment.entity.Comment;
-import hng_java_boilerplate.comment.repository.CommentRepository;
-import hng_java_boilerplate.exception.UnAuthorizedException;
-import hng_java_boilerplate.user.entity.User;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
+import hng_java_boilerplate.comment.entity.Comment;
+import hng_java_boilerplate.comment.repository.CommentRepository;
+import hng_java_boilerplate.exception.UnAuthorizedException;
+import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
 
     public Comment createComment(String userId, String name,  String comment){
         User user = new User();
@@ -29,22 +33,50 @@ public class CommentService {
     }
 
     public Boolean isUserAuthorizedToDeleteComment(String commentId, String username){
-        Comment comment = commentRepository.findById(commentId).orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
+        Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
 
         return comment.getUser().getId().equals(username);
 
     }
 
-    public Comment softDeleteComment(String commentId, String userId){
-        Comment comment = commentRepository.findByCommentIdAndDeletedFalse(commentId).orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
+    public Boolean isUserAuthorizedToUpdateComment(String commentId, String username) {
+        Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
+        return null;
+    }
+    
+    public Comment softDeleteComment (String commentId, String userId){
+        Comment comment = commentRepository.findByCommentIdAndDeletedFalse(commentId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
 
-        if(!comment.getUser().getId().equals(userId)){
+        if (!comment.getUser().getId().equals(userId)) {
             throw new UnAuthorizedException("Unauthorized user");
         }
         comment.setDeleted(true);
         comment.setUpdatedAt(LocalDateTime.now());
         return commentRepository.save(comment);
-    }
+        }
 
+// The service that handles the logic for updating a comment
+// The method takes in the commentId, userId, and the new comment text
+// It returns the updated comment
+    public Comment updateComment(String commentId, String userId, String newCommentText) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
+        
+        // Ensure the user exists
+        userRepository.findById(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+    
+        // Authorization check
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new UnAuthorizedException("Unable to update comment");
+        } 
+    
+        // Update the comment text
+        comment.setComment(newCommentText);
+        return commentRepository.save(comment);
+    }    
 
 }

--- a/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
+++ b/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
 
     public Boolean isUserAuthorizedToDeleteComment(String commentId, String username){
         Comment comment = commentRepository.findById(commentId)
-        .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
+        .orElseThrow(()-> new NotFoundException("comment not found"));
 
         return comment.getUser().getId().equals(username);
 
@@ -43,7 +43,7 @@ public class CommentService {
 
     public Boolean isUserAuthorizedToUpdateComment(String commentId, String username) {
         Comment comment = commentRepository.findById(commentId)
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
+        .orElseThrow(() -> new NotFoundException("comment not found"));
         return null;
     }
     
@@ -66,9 +66,7 @@ public class CommentService {
             .orElseThrow(() -> new NotFoundException("User not found"));
         if (!comment.getUser().getId().equals(userId)) {
             throw new UnAuthorizedException("Unable to update comment");
-        } 
-    
-        // Update the comment text
+        }
         comment.setComment(newCommentText);
         return commentRepository.save(comment);
     }    

--- a/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
+++ b/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
@@ -64,8 +64,6 @@ public class CommentService {
     public Comment updateComment(String commentId, String userId, String newCommentText) {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
-
-
         
         // Ensure the user exists
         userRepository.findById(userId)

--- a/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
+++ b/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
@@ -64,6 +64,8 @@ public class CommentService {
     public Comment updateComment(String commentId, String userId, String newCommentText) {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
+
+
         
         // Ensure the user exists
         userRepository.findById(userId)

--- a/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
+++ b/src/main/java/hng_java_boilerplate/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package hng_java_boilerplate.comment.service;
 
 import java.time.LocalDateTime;
 
+import hng_java_boilerplate.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -48,7 +49,7 @@ public class CommentService {
     
     public Comment softDeleteComment (String commentId, String userId){
         Comment comment = commentRepository.findByCommentIdAndDeletedFalse(commentId)
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
+        .orElseThrow(() -> new NotFoundException("Comment not found"));
 
         if (!comment.getUser().getId().equals(userId)) {
             throw new UnAuthorizedException("Unauthorized user");
@@ -58,18 +59,11 @@ public class CommentService {
         return commentRepository.save(comment);
         }
 
-// The service that handles the logic for updating a comment
-// The method takes in the commentId, userId, and the new comment text
-// It returns the updated comment
     public Comment updateComment(String commentId, String userId, String newCommentText) {
         Comment comment = commentRepository.findById(commentId)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found"));
-        
-        // Ensure the user exists
+            .orElseThrow(() -> new NotFoundException("Comment not found"));
         userRepository.findById(userId)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
-    
-        // Authorization check
+            .orElseThrow(() -> new NotFoundException("User not found"));
         if (!comment.getUser().getId().equals(userId)) {
             throw new UnAuthorizedException("Unable to update comment");
         } 

--- a/src/test/java/hng_java_boilerplate/comment_unit_test/CommentServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/comment_unit_test/CommentServiceTest.java
@@ -5,6 +5,8 @@ import hng_java_boilerplate.comment.repository.CommentRepository;
 import hng_java_boilerplate.comment.service.CommentService;
 import hng_java_boilerplate.exception.UnAuthorizedException;
 import hng_java_boilerplate.user.entity.User;
+import hng_java_boilerplate.user.repository.UserRepository;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -26,6 +28,9 @@ class CommentServiceTest {
 
     @InjectMocks
     private CommentService commentService;
+
+    @Mock
+    private UserRepository userRepository;
 
     @BeforeEach
     void setUp() {
@@ -143,4 +148,33 @@ class CommentServiceTest {
         assertThrows(UnAuthorizedException.class, () ->
                 commentService.softDeleteComment(commentId, userId));
     }
+
+
+
+    
+
+    @Test
+    void updateComment_ShouldThrowUnauthorizedExceptionIfUserIsNotAuthorized() {
+        String commentId = "comment1";
+        String userId = "user1";
+        String differentUserId = "user2";
+        String newCommentText = "This is my updated comment.";
+
+        User user = new User();
+        user.setId(differentUserId);
+
+        Comment comment = new Comment();
+        comment.setCommentId(commentId);
+        comment.setUser(user);
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
+    
+        assertThrows(UnAuthorizedException.class, () ->
+                commentService.updateComment(commentId, userId, newCommentText));
+    
+        verify(commentRepository, times(1)).findById(commentId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
 }

--- a/src/test/java/hng_java_boilerplate/comment_unit_test/CommentServiceTest.java
+++ b/src/test/java/hng_java_boilerplate/comment_unit_test/CommentServiceTest.java
@@ -169,7 +169,6 @@ class CommentServiceTest {
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
         when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
-    
         assertThrows(UnAuthorizedException.class, () ->
                 commentService.updateComment(commentId, userId, newCommentText));
     


### PR DESCRIPTION
**Description**
Users should be able to edit comments they have made.

**Acceptance** **Criteria**
A user can update their own comments.
**Endpoint**
`PUT   /edit/{commentId}`

**Payload**

```
{
"commentId": "comment ID"
"userId": "user@gmail.com"
}
```
**Response**

```
{
  "status": "200",
  "message": "The account has been successfully edited.",
}
```
Proper authorization checks should be in place to prevent unauthorized editing.
**Purpose**
Allow users to manage their own content.
**Requirements**
Implement role-based access control (RBAC) to ensure only authorized users can edit comments.

Ensure database consistency and integrity after editing

Handle potential errors such as trying to edit a non-existent comment.

Provide a PUT API endpoint.

Expected Outcome
Users can edit their own comments.
Edit comments are either removed or replaced with a placeholder message.
Unauthorized users cannot edit comments.