### PR TITLE
Feat: Added custom repository functions in NewsletterRepository and endpoints

### DIFF
--- a/src/main/java/hng_java_boilerplate/newsletter/controller/NewsletterController.java
+++ b/src/main/java/hng_java_boilerplate/newsletter/controller/NewsletterController.java
@@ -1,12 +1,14 @@
 package hng_java_boilerplate.newsletter.controller;
 
-import hng_java_boilerplate.categories.dto.CategoryDto;
-import hng_java_boilerplate.exception.ErrorResponseDto;
+import hng_java_boilerplate.exception.BadRequestException;
 import hng_java_boilerplate.exception.ValidationError;
+import hng_java_boilerplate.newsletter.dto.DeleteNewsletterRequest;
 import hng_java_boilerplate.newsletter.dto.SubscribeRequest;
 import hng_java_boilerplate.newsletter.dto.SubscribeResponse;
 import hng_java_boilerplate.newsletter.dto.SubscribersResponse;
+import hng_java_boilerplate.newsletter.entity.Newsletter;
 import hng_java_boilerplate.newsletter.service.NewsletterService;
+import hng_java_boilerplate.user.dto.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,13 +17,20 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/newsletter-subscription")
+@RequestMapping("/api/v1/newsletter")
 @Tag(name = "NewsLetter", description = "controller for newsletter")
 public class NewsletterController {
     private final NewsletterService newsletterService;
@@ -40,6 +49,29 @@ public class NewsletterController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(newsletterService.subscribeToNewsletter(request));
     }
+
+    @GetMapping("/{email}")
+    public ResponseEntity<Page<Newsletter>> getNewslettersByEmail(@PathVariable String email, @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(newsletterService.findNewsletterByEmail(email,pageable));
+    }
+
+    @GetMapping("/date/{date}")
+    public ResponseEntity<Page<Newsletter>> getNewslettersAfterDate(@PathVariable LocalDateTime date, @PageableDefault(sort = "createdAt",direction = Sort.Direction.DESC)Pageable pageable) {
+        return ResponseEntity.ok(newsletterService.findNewsletterByCreatedAtAfter(date,pageable));
+    }
+
+    @PreAuthorize("hasRole('ROLE_SUPER_ADMIN')")
+    @DeleteMapping
+    public ResponseEntity<?> deleteNewslettersByEmail(@Valid @RequestBody DeleteNewsletterRequest request) {
+        String user_id = request.getEmail();
+        if(user_id.isEmpty()){
+            throw new BadRequestException("user id is required");
+        }else {
+            Response<?> response = newsletterService.deleteNewsletterByUserId(user_id);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        }
+    }
+
 
     @GetMapping
     public ResponseEntity<SubscribersResponse> getSubscribers(

--- a/src/main/java/hng_java_boilerplate/newsletter/dto/DeleteNewsletterRequest.java
+++ b/src/main/java/hng_java_boilerplate/newsletter/dto/DeleteNewsletterRequest.java
@@ -1,0 +1,10 @@
+package hng_java_boilerplate.newsletter.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DeleteNewsletterRequest {
+    private String email;
+}

--- a/src/main/java/hng_java_boilerplate/newsletter/entity/Newsletter.java
+++ b/src/main/java/hng_java_boilerplate/newsletter/entity/Newsletter.java
@@ -19,11 +19,16 @@ public class Newsletter {
     @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
     @Column(nullable = false)
-    private String userId;
+    private String email;
+    @Column(name = "email")
+    private String title;
+    @Column(nullable = false)
+    private String content;
     @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createdAt;
     @Column
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
 }

--- a/src/main/java/hng_java_boilerplate/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/hng_java_boilerplate/newsletter/repository/NewsletterRepository.java
@@ -1,7 +1,21 @@
 package hng_java_boilerplate.newsletter.repository;
 
 import hng_java_boilerplate.newsletter.entity.Newsletter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface NewsletterRepository extends JpaRepository<Newsletter, String> {
+
+
+    Page<Newsletter> findByEmail(String email, Pageable page);
+
+    @Query("SELECT n FROM Newsletter n WHERE n.createdAt > :date")
+    <Optional> Page<Newsletter> findNewsletterByCreatedAtAfter(@Param("date") LocalDateTime date, Pageable page);
+
+    void deleteByEmail(String userId);
 }

--- a/src/main/java/hng_java_boilerplate/newsletter/service/NewsletterService.java
+++ b/src/main/java/hng_java_boilerplate/newsletter/service/NewsletterService.java
@@ -7,6 +7,7 @@ import hng_java_boilerplate.newsletter.dto.SubscribersDto;
 import hng_java_boilerplate.newsletter.dto.SubscribersResponse;
 import hng_java_boilerplate.newsletter.entity.Newsletter;
 import hng_java_boilerplate.newsletter.repository.NewsletterRepository;
+import hng_java_boilerplate.user.dto.response.Response;
 import hng_java_boilerplate.user.entity.User;
 import hng_java_boilerplate.user.repository.UserRepository;
 import hng_java_boilerplate.user.serviceImpl.EmailServiceImpl;
@@ -30,7 +31,7 @@ public class NewsletterService {
                .orElseThrow(() -> new NotFoundException("user not found with email"));
 
        Newsletter newsletter = new Newsletter();
-       newsletter.setUserId(user.getId());
+       newsletter.setEmail(user.getEmail());
        newsletter.setCreatedAt(LocalDateTime.now());
        newsletter.setUpdatedAt(LocalDateTime.now());
        newsletterRepository.saveAndFlush(newsletter);
@@ -54,15 +55,11 @@ public class NewsletterService {
 
     private List<SubscribersDto> mapNewslettersToSubscribers(List<Newsletter> newsletters) {
         return newsletters.stream()
-                .map(newsletter -> {
-                    User user = userRepository.findById(newsletter.getUserId())
-                            .orElseThrow(() -> new NotFoundException("User not found for subscription id: " + newsletter.getId()));
-                    return SubscribersDto.builder()
-                            .id(newsletter.getId())
-                            .email(user.getEmail())
-                            .subscribedAt(newsletter.getCreatedAt())
-                            .build();
-                })
+                .map(newsletter -> SubscribersDto.builder()
+                        .id(newsletter.getId())
+                        .email(newsletter.getEmail())
+                        .subscribedAt(newsletter.getCreatedAt())
+                        .build())
                 .collect(Collectors.toList());
     }
 
@@ -74,5 +71,18 @@ public class NewsletterService {
                 .totalElements(newsletterPage.getTotalElements())
                 .totalPages(newsletterPage.getTotalPages())
                 .build();
+    }
+
+    public Page<Newsletter> findNewsletterByEmail(String email, Pageable pageable){
+        return newsletterRepository.findByEmail(email,pageable);
+    }
+
+    public Page<Newsletter> findNewsletterByCreatedAtAfter(LocalDateTime date, Pageable pageable){
+        return newsletterRepository.findNewsletterByCreatedAtAfter(date,pageable);
+    }
+
+    public Response<?> deleteNewsletterByUserId(String email){
+        newsletterRepository.deleteByEmail(email);
+        return Response.builder().status_code("success").message("Newsletter deleted successfully.").build();
     }
 }

--- a/src/main/java/hng_java_boilerplate/user/entity/User.java
+++ b/src/main/java/hng_java_boilerplate/user/entity/User.java
@@ -1,6 +1,7 @@
 package hng_java_boilerplate.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import hng_java_boilerplate.newsletter.entity.Newsletter;
 import hng_java_boilerplate.organisation.entity.Organisation;
 import hng_java_boilerplate.plans.entity.Plan;
 import hng_java_boilerplate.product.entity.Product;
@@ -122,4 +123,12 @@ public class User implements UserDetails {
     public boolean isEnabled() {
         return this.isEnabled;
     }
+
+    @ManyToMany
+    @JoinTable(
+            name = "subscribers",
+            joinColumns = @JoinColumn(name = "email"),
+            inverseJoinColumns = @JoinColumn(name = "newsletter_id")
+    )
+    private List<Newsletter> newsletters;
 }

--- a/src/main/resources/db/migration/V49__alter_newsletter_and create subscription_table.sql
+++ b/src/main/resources/db/migration/V49__alter_newsletter_and create subscription_table.sql
@@ -1,0 +1,18 @@
+ALTER TABLE newsletters
+DROP COLUMN user_id;
+
+ALTER TABLE newsletters
+ADD COLUMN title VARCHAR(255);
+
+ALTER TABLE newsletters
+ADD COLUMN email VARCHAR(255);
+
+ALTER TABLE newsletters
+ADD COLUMN content TEXT;
+
+CREATE TABLE subscribers(
+    email VARCHAR(50),
+    newsletter_id VARCHAR(50),
+    PRIMARY KEY (newsletter_id),
+    FOREIGN KEY (newsletter_id) REFERENCES newsletters(id),
+    subscribed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);

--- a/src/test/java/hng_java_boilerplate/newsletter/unit_test/NewsletterTest.java
+++ b/src/test/java/hng_java_boilerplate/newsletter/unit_test/NewsletterTest.java
@@ -1,0 +1,100 @@
+package hng_java_boilerplate.newsletter.unit_test;
+
+import hng_java_boilerplate.newsletter.entity.Newsletter;
+import hng_java_boilerplate.newsletter.repository.NewsletterRepository;
+import hng_java_boilerplate.newsletter.service.NewsletterService;
+import hng_java_boilerplate.user.dto.response.Response;
+import hng_java_boilerplate.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class NewsletterTest {
+
+    @InjectMocks
+    private NewsletterService newsletterService;
+    @Mock
+    private NewsletterRepository newsletterRepository;
+
+    private Newsletter newsletter1;
+    private Newsletter newsletter2;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        User user = new User();
+        user.setId("U1");
+        user.setName("John Doe");
+        user.setEmail("johndoe@example.com");
+        user.setCreatedAt(LocalDateTime.now());
+
+        newsletter1 = new Newsletter();
+        newsletter1.setEmail(user.getEmail());
+        newsletter1.setCreatedAt(LocalDateTime.now());
+        newsletter1.setId("1");
+        newsletter1.setTitle("Newsletter test");
+        newsletter1.setUpdatedAt(LocalDateTime.now());
+        newsletter1.setContent("this a test content for the newsletter");
+
+        newsletter2 = new Newsletter();
+        newsletter1.setEmail(user.getEmail());
+        newsletter2.setCreatedAt(LocalDateTime.now());
+        newsletter2.setId("2");
+        newsletter2.setUpdatedAt(LocalDateTime.now());
+        newsletter2.setTitle("Newsletter test2");
+        newsletter2.setContent("this a second test content for the newsletter");
+    }
+
+    @Test
+    void testFindByUserId(){
+        List<Newsletter> newsletters = Arrays.asList(newsletter1,newsletter2);
+        Page<Newsletter> page = new PageImpl<>(newsletters);
+        Pageable pageable = PageRequest.of(0,1);
+
+        when(newsletterRepository.findByEmail("U1",pageable)).thenReturn(page);
+
+        Page<Newsletter> result = newsletterService.findNewsletterByEmail(newsletter1.getEmail(),pageable);
+
+        assertNotNull(result);
+        assertEquals(1,result.getTotalPages());
+        verify(newsletterRepository, times(1)).findByEmail(newsletter1.getEmail(),pageable);
+    }
+
+    @Test
+    void testFindByCreatedAfter(){
+        List<Newsletter> newsletters = Arrays.asList(newsletter1,newsletter2);
+        Page<Newsletter> page = new PageImpl<>(newsletters,PageRequest.of(0,1),2);
+        LocalDateTime date = LocalDateTime.parse("2025-02-28T11:44:32.180026100");
+        when(newsletterRepository.findNewsletterByCreatedAtAfter(date,page.getPageable())).thenReturn(page);
+
+        Page<Newsletter> result = newsletterService.findNewsletterByCreatedAtAfter(date,page.getPageable());
+
+        assertNotNull(result);
+        verify(newsletterRepository, times(1)).findNewsletterByCreatedAtAfter(date,page.getPageable());
+    }
+
+    @Test
+    void testDeleteByUserId(){
+        String email = newsletter1.getEmail();
+
+        Response<?> response = newsletterService.deleteNewsletterByUserId(email);
+
+        assertEquals("success", response.getStatus_code());
+        assertEquals("Newsletter deleted successfully.", response.getMessage());
+        verify(newsletterRepository, times(1)).deleteByEmail(email);
+    }
+}


### PR DESCRIPTION
## PR Description

This PR resolves the incorrect configuration of the `NewsletterRepository interface` and implements CRUD features, including retrieving newsletters by user ID, retrieving newsletters created after a specified date, and deleting newsletters by user ID.

## Bug fixes:
 *Resolved incorrect configuration of `NewsletterRepository` interface

##New features:
* Implemented CRUD features for NewsletterRepository interface
* Added content and title fields to `@Entity newsletter`
* Added unit tests for NewsletterRepository methods

## Expected Behavior

The `NewsletterRepository` should correctly perform CRUD operations using the defined `@Query` annotations.

### `getNewslettersByUserId` Endpoint
![postman](https://github.com/user-attachments/assets/40b1fcb2-e9ce-4394-ba76-3ff523fa3071)

### `getNewslettersAfterDate` Endpoint
![posttman2](https://github.com/user-attachments/assets/896139d1-4399-483c-a3e0-27c5edf171a9)



## Testing

### Test 1: Retrieve newsletters by user ID

* **Unit test:** passed

### Test 2: Retrieve newsletters created after a specified date

* **Unit test:** passed

### Test 3: Delete newsletter by user ID

* **Unit test:** passed